### PR TITLE
Add optional notifications support through SNS

### DIFF
--- a/notifications.tf
+++ b/notifications.tf
@@ -1,0 +1,48 @@
+locals {
+    # Whether to enable notifications or not
+    enable_notifications = var.enabled && length(var.notifications_backup_vault_events) > 0 ? true : false
+}
+
+resource "aws_sns_topic" "backup_events" {
+  count  = local.enable_notifications ? 1 : 0
+  name = var.notifications_sns_topic_name
+}
+
+data "aws_iam_policy_document" "backup_events" {
+  statement {
+    actions = [
+      "SNS:Publish",
+    ]
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["backup.amazonaws.com"]
+    }
+    resources = [
+      local.enable_notifications ? aws_sns_topic.backup_events[0].arn : "",
+    ]
+    sid = "BackupPublishEvents"
+  }
+}
+
+resource "aws_sns_topic_policy" "backup_events" {
+  count  = local.enable_notifications ? 1 : 0
+  arn    = aws_sns_topic.backup_events[0].arn
+  policy = data.aws_iam_policy_document.backup_events.json
+}
+
+resource "aws_backup_vault_notifications" "backup_events" {
+  count               = local.enable_notifications ? 1 : 0
+  backup_vault_name   = var.vault_name != null ? var.vault_name : "Default"
+  sns_topic_arn       = aws_sns_topic.backup_events[0].arn
+  backup_vault_events = var.notifications_backup_vault_events
+}
+
+resource "aws_sns_topic_subscription" "backup_events" {
+  for_each = var.notifications_topic_subscriptions
+
+  topic_arn              = aws_sns_topic.backup_events[0].arn
+  protocol               = var.notifications_topic_subscriptions[each.key].protocol
+  endpoint               = var.notifications_topic_subscriptions[each.key].endpoint
+  endpoint_auto_confirms = var.notifications_topic_subscriptions[each.key].endpoint_auto_confirms
+}

--- a/variables.tf
+++ b/variables.tf
@@ -142,3 +142,31 @@ variable "windows_vss_backup" {
   type        = bool
   default     = false
 }
+
+#
+# Notifications
+#
+variable "notifications_backup_vault_events" {
+  description = "A list of backup events that you would like to be notified about. Leave it empty to disable notifications."
+  type        = list
+  default     = []
+}
+
+variable "notifications_sns_topic_name" {
+  description = "A name for the SNS topic that will be created to receive AWS Backup Vault notifications."
+  type        = string
+  default     = "backup-events"
+}
+
+variable "notifications_topic_subscriptions" {
+  description = "A map of subscriptions you would like to subscribe to the SNS topic."
+  type = map(object({
+    protocol = string
+    # The protocol to use. The possible values for this are: sqs, sms, lambda, application. (http or https are partially supported, see below) (email is an option but is unsupported, see below).
+    endpoint = string
+    # The endpoint to send data to, the contents will vary with the protocol. (see below for more information)
+    endpoint_auto_confirms = bool
+    # Boolean indicating whether the end point is capable of auto confirming subscription e.g., PagerDuty (default is false)
+  }))
+  default     = {}
+}


### PR DESCRIPTION
Optional notifications support was added. It can create an SNS topic and add subscriptors to it.
This functionality is useful to be notified about successful/failed backups, restore jobs, copy jobs and more backup-related events.