### PR TITLE
Allows attaching an already created IAM role

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ module "aws_backup_example" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | enabled | Change to false to avoid deploying any AWS Backup resources | `bool` | `true` | no |
+| iam\_role\_arn | If configured, the module will attach this role to selections, instead of creating IAM resources by itself | `string` | `null` | no |
 | notifications | Notification block which defines backup vault events and the SNS Topic ARN to send AWS Backup notifications to. Leave it empty to disable notifications | `any` | `{}` | no |
 | plan\_name | The display name of a backup plan | `string` | n/a | yes |
 | rule\_completion\_window | The amount of time AWS Backup attempts a backup before canceling the job and returning an error | `number` | `null` | no |
@@ -160,7 +161,7 @@ module.aws_backup_example.aws_iam_policy.ab_tag_policy: Destruction complete aft
 module.aws_backup_example.aws_iam_role.ab_role: Destruction complete after 1s
 
 Error: error deleting Backup Plan: InvalidRequestException: Related backup plan selections must be deleted prior to backup plan deletion
-	status code: 400, request id: 4a6637c8-2d46-4714-9929-4df3f694979b
+       status code: 400, request id: 4a6637c8-2d46-4714-9929-4df3f694979b
 
 ```
 
@@ -193,7 +194,7 @@ terraform destroy
 
 ```
 Error: error creating Backup Selection: InvalidParameterValueException: IAM Role arn:aws:iam::111111111111:role/aws-backup-plan-complete-plan-role is not authorized to call tag:GetResources
-	status code: 400, request id: 07ab775d-8885-4240-bb99-41305df969e0
+       status code: 400, request id: 07ab775d-8885-4240-bb99-41305df969e0
 
   on .terraform/modules/aws_backup_example/selection.tf line 1, in resource "aws_backup_selection" "ab_selection":
    1: resource "aws_backup_selection" "ab_selection" {

--- a/iam.tf
+++ b/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "ab_role" {
-  count              = var.enabled ? 1 : 0
+  count              = var.enabled && var.iam_role_arn == null ? 1 : 0
   name               = "aws-backup-plan-${var.plan_name}-role"
   assume_role_policy = <<POLICY
 {
@@ -20,7 +20,7 @@ POLICY
 }
 
 resource "aws_iam_role_policy_attachment" "ab_policy_attach" {
-  count      = var.enabled ? 1 : 0
+  count      = var.enabled && var.iam_role_arn == null ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
   role       = aws_iam_role.ab_role[0].name
 }
@@ -28,7 +28,7 @@ resource "aws_iam_role_policy_attachment" "ab_policy_attach" {
 # Tag policy
 resource "aws_iam_policy" "ab_tag_policy" {
 
-  count       = var.enabled ? 1 : 0
+  count       = var.enabled && var.iam_role_arn == null ? 1 : 0
   description = "AWS Backup Tag policy"
 
   policy = <<EOF
@@ -52,7 +52,7 @@ EOF
 
 
 resource "aws_iam_role_policy_attachment" "ab_tag_policy_attach" {
-  count      = var.enabled ? 1 : 0
+  count      = var.enabled && var.iam_role_arn == null ? 1 : 0
   policy_arn = aws_iam_policy.ab_tag_policy[0].arn
   role       = aws_iam_role.ab_role[0].name
 }
@@ -60,7 +60,7 @@ resource "aws_iam_role_policy_attachment" "ab_tag_policy_attach" {
 
 # Restores policy
 resource "aws_iam_role_policy_attachment" "ab_restores_policy_attach" {
-  count      = var.enabled ? 1 : 0
+  count      = var.enabled && var.iam_role_arn == null ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
   role       = aws_iam_role.ab_role[0].name
 }

--- a/selection.tf
+++ b/selection.tf
@@ -2,7 +2,7 @@ resource "aws_backup_selection" "ab_selection" {
 
   count = var.enabled ? length(local.selections) : 0
 
-  iam_role_arn = aws_iam_role.ab_role[0].arn
+  iam_role_arn = var.iam_role_arn ? var.iam_role_arn : aws_iam_role.ab_role[0].arn
   name         = lookup(element(local.selections, count.index), "name", null)
   plan_id      = aws_backup_plan.ab_plan[0].id
 

--- a/variables.tf
+++ b/variables.tf
@@ -151,3 +151,12 @@ variable "notifications" {
   type        = any
   default     = {}
 }
+
+#
+# IAM
+#
+variable "iam_role_arn" {
+  description = "If configured, the module will attach this role to selections, instead of creating IAM resources by itself"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
A workaround to allow attaching an already created IAM role, if you need so for some reason.