### PR TITLE
Fixed error when missing optional vault_name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,13 @@ resource "aws_backup_plan" "ab_plan" {
     for_each = local.rules
     content {
       rule_name                = lookup(rule.value, "name", null)
-      target_vault_name        = lookup(rule.value, "target_vault_name", null) == null ? var.vault_name : lookup(rule.value, "target_vault_name", "Default")
+      target_vault_name        = (
+        lookup(rule.value, "target_vault_name", null) != null ?
+        rule.value.target_vault_name :
+        var.vault_name != null ?
+        var.vault_name :
+        "Default"
+      )
       schedule                 = lookup(rule.value, "schedule", null)
       start_window             = lookup(rule.value, "start_window", null)
       completion_window        = lookup(rule.value, "completion_window", null)


### PR DESCRIPTION
Under **Inputs**, `vault_name` is marked as **not required**.
However, failing to provide this variable causes the module to complain about a missing `target_vault_name` -- _which is not listed under **Inputs**_ -- and throws this error:

> Error: Missing required argument
> 
>   with module.rds_backup.aws_backup_plan.ab_plan[0],
>   on .terraform/modules/rds_backup/main.tf line 10, in resource "aws_backup_plan" "ab_plan":
>   10: resource "aws_backup_plan" "ab_plan" {
> 
> The argument "rule.1.target_vault_name" is required, but no definition was found.

This PR should modify this behavior so that, it first looks up the value of `target_vault_name`, then `vault_name`, and finally returns `Default` in case neither is set.