### PR TITLE
Fix terraform version constraints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-added-large-files
     -   id: detect-aws-credentials
-- repo: git://github.com/antonbabenko/pre-commit-terraform
+- repo: https://github.com/antonbabenko/pre-commit-terraform
   rev: v1.62.3 # Get the latest from: https://github.com/antonbabenko/pre-commit-terraform/releases
   hooks:
     - id: terraform_fmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## 0.15.0 (April 29, 2022)
 
-ENHANCEMENTS:
+FIXES:
 
 * Add constrainst for Terraform & AWS provider versions
+* Remove provider contrainst in examples
 
 ## 0.14.0 (March 3, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.15.0 (April 29, 2022)
+
+ENHANCEMENTS:
+
+* Add constrainst for Terraform & AWS provider versions
+
 ## 0.14.0 (March 3, 2022)
 
 ENHANCEMENTS:

--- a/README.md
+++ b/README.md
@@ -148,14 +148,14 @@ module "aws_backup_example" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.20.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.1 |
 
 ## Modules
 

--- a/examples/complete_plan/provider.tf
+++ b/examples/complete_plan/provider.tf
@@ -1,12 +1,3 @@
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.0"
-    }
-  }
-}
-
 provider "aws" {
   region  = var.env["region"]
   profile = var.env["profile"]

--- a/examples/simple_plan/provider.tf
+++ b/examples/simple_plan/provider.tf
@@ -1,12 +1,3 @@
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.0"
-    }
-  }
-}
-
 provider "aws" {
   region  = var.env["region"]
   profile = var.env["profile"]

--- a/examples/simple_plan_using_variables/provider.tf
+++ b/examples/simple_plan_using_variables/provider.tf
@@ -1,12 +1,3 @@
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.0"
-    }
-  }
-}
-
 provider "aws" {
   region  = var.env["region"]
   profile = var.env["profile"]

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.20.0"
+      version = "~> 3.0"
     }
   }
 }


### PR DESCRIPTION
As reported in #58, there were some incompatibilities issues among Terraform versions and the AWS provider for Terraform version `0.12.x.`

After checking, the lower Terraform version that downloads a AWS provider higher than `3.72.0 `is Terraform version `0.12.31`. 

It closes #58 