### PR TITLE
Fix incosistent output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -27,5 +27,5 @@ output "plan_version" {
 
 output "plan_role" {
   description = "The service role of the backup plan"
-  value       = var.iam_role_arn == null ? join("", aws_iam_role.ab_role.*.name) : var.iam_role_arn
+  value       = var.iam_role_arn == null ? join("", aws_iam_role.ab_role.*.arn) : var.iam_role_arn
 }


### PR DESCRIPTION
The output "plan_role" was sometimes an ARN and sometimes a name (depending of the var inputs). 

I think it should return the same type in both cases