### PR TITLE
feat: only create aws_backup_plan if rules are provided

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ resource "aws_backup_vault_lock_configuration" "ab_vault_lock_configuration" {
 
 # AWS Backup plan
 resource "aws_backup_plan" "ab_plan" {
-  count = var.enabled ? 1 : 0
+  count = var.enabled && length(local.rules) > 0 ? 1 : 0
   name  = var.plan_name
 
   # Rules

--- a/variables.tf
+++ b/variables.tf
@@ -58,6 +58,7 @@ variable "min_retention_days" {
 variable "plan_name" {
   description = "The display name of a backup plan"
   type        = string
+  default     = null
 }
 
 # Default rule


### PR DESCRIPTION
Thanks for the module :pray:
I'd like to be able to use the same module when creating a standalone vault with no rules to be referenced in a cross-region copy action of another plan.

- Updates `aws_backup_plan` resource count to prevent creation if no plan rules are specified.