### PR TITLE
fix: Update README icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![AWS Backup](https://github.com/lgallard/terraform-aws-backup/raw/master/images/aws-backup.png)
+![Terraform](https://lgallardo.com/images/terraform.jpg)
 
 # terraform-aws-backup
 


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the image URL from an AWS Backup image to a Terraform image.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1): Updated the image URL to use a Terraform image instead of an AWS Backup image.