### PR TITLE
fix: retention days validations

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,19 +10,12 @@ resource "aws_backup_vault" "ab_vault" {
 
 # AWS Backup vault lock configuration
 resource "aws_backup_vault_lock_configuration" "ab_vault_lock_configuration" {
-  count = var.locked && var.vault_name != null ? 1 : 0
+  count = var.enabled && var.vault_name != null && var.locked ? 1 : 0
 
   backup_vault_name   = aws_backup_vault.ab_vault[0].name
-  changeable_for_days = var.changeable_for_days
-  max_retention_days  = var.max_retention_days
   min_retention_days  = var.min_retention_days
-
-  lifecycle {
-    precondition {
-      condition     = var.min_retention_days != null && var.max_retention_days != null && var.min_retention_days <= var.max_retention_days
-      error_message = "For vault lock configuration, min_retention_days and max_retention_days must be provided and min_retention_days must be less than or equal to max_retention_days."
-    }
-  }
+  max_retention_days  = var.max_retention_days
+  changeable_for_days = var.changeable_for_days
 }
 
 # AWS Backup plan

--- a/main.tf
+++ b/main.tf
@@ -6,13 +6,6 @@ resource "aws_backup_vault" "ab_vault" {
   kms_key_arn   = var.vault_kms_key_arn
   force_destroy = var.vault_force_destroy
   tags          = var.tags
-
-  lifecycle {
-    precondition {
-      condition     = !var.locked || (var.min_retention_days != null && var.max_retention_days != null && var.min_retention_days <= var.max_retention_days)
-      error_message = "When vault locking is enabled, min_retention_days and max_retention_days must be provided and min_retention_days must be less than or equal to max_retention_days."
-    }
-  }
 }
 
 # AWS Backup vault lock configuration
@@ -23,6 +16,13 @@ resource "aws_backup_vault_lock_configuration" "ab_vault_lock_configuration" {
   changeable_for_days = var.changeable_for_days
   max_retention_days  = var.max_retention_days
   min_retention_days  = var.min_retention_days
+
+  lifecycle {
+    precondition {
+      condition     = var.min_retention_days != null && var.max_retention_days != null && var.min_retention_days <= var.max_retention_days
+      error_message = "For vault lock configuration, min_retention_days and max_retention_days must be provided and min_retention_days must be less than or equal to max_retention_days."
+    }
+  }
 }
 
 # AWS Backup plan

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,11 @@ variable "locked" {
   description = "Change to true to add a lock configuration for the backup vault"
   type        = bool
   default     = false
+
+  validation {
+    condition     = !var.locked || (var.min_retention_days != null && var.max_retention_days != null && var.min_retention_days <= var.max_retention_days)
+    error_message = "When vault locking is enabled (locked = true), min_retention_days and max_retention_days must be provided and min_retention_days must be less than or equal to max_retention_days."
+  }
 }
 
 variable "changeable_for_days" {


### PR DESCRIPTION
This pull request includes changes to the Terraform configuration for AWS Backup vaults, specifically focusing on improving the validation and configuration logic. The most important changes include the removal of the lifecycle precondition from the `aws_backup_vault` resource and the addition of validation logic to the `locked` variable.

Validation and configuration improvements:

* [`main.tf`](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL9-R18): Removed the lifecycle precondition block from the `aws_backup_vault` resource and adjusted the `count` condition in the `aws_backup_vault_lock_configuration` resource to include the `enabled` variable.
* [`variables.tf`](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR45-R49): Added a validation block to the `locked` variable to ensure that `min_retention_days` and `max_retention_days` are provided and that `min_retention_days` is less than or equal to `max_retention_days` when vault locking is enabled.