### PR TITLE
chore: customize release-please configuration

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -29,6 +29,8 @@
   "release-search-depth": 10,
   "include-component-in-tag": false,
   "include-v-in-tag": false,
+  "release-title-pattern": "${package-name} ${version}",
+  "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
   "date-formats": {
     "changelogDate": "(%B %d, %Y)"
   }


### PR DESCRIPTION
- Remove "v" prefix from tags and release titles
- Format GitHub release titles with package name and version