### PR TITLE
fix: Enhance Windows VSS backup validation and add example configuration

### DIFF
--- a/examples/simple_plan_windows_vss_backup/README.md
+++ b/examples/simple_plan_windows_vss_backup/README.md
@@ -1,0 +1,68 @@
+# Windows VSS Backup Example
+
+This example demonstrates the Windows VSS (Volume Shadow Copy Service) backup functionality of the AWS Backup module. Windows VSS is a feature that allows for consistent backups of Windows EC2 instances.
+
+## Usage
+
+To run this example, execute:
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+## Testing the Validation Logic
+
+This example includes proper configuration with EC2 instances in the selection, which is required when Windows VSS backup is enabled.
+
+### Testing the Error Case
+
+To test the error case (when Windows VSS is enabled but no EC2 instances are selected), modify the `main.tf` file:
+
+1. Comment out the current `selection_resources` block
+2. Uncomment the error test case below
+3. Run `terraform plan`
+
+```terraform
+  # Comment out the current selection_resources
+  /*
+  selection_resources = [
+    "arn:aws:ec2:us-west-2:123456789012:instance/i-1234567890abcdef0",
+    "arn:aws:dynamodb:us-west-2:123456789012:table/my-table"
+  ]
+  */
+
+  # Uncomment this to test the error case
+  selection_resources = [
+    # No EC2 instances here - will trigger the validation error
+    "arn:aws:dynamodb:us-west-2:123456789012:table/my-table"
+  ]
+```
+
+You should see an error message:
+
+```
+Error: Resource precondition failed
+
+  on .terraform/modules/backup/main.tf line XX, in resource "aws_backup_plan" "ab_plan":
+   XX:     condition     = !var.windows_vss_backup || (length(local.selection_resources) > 0 && can(regex(".*EC2.*", join(",", local.selection_resources))))
+     ├────────────────
+     │ local.selection_resources doesn't contain EC2 instances
+     │ var.windows_vss_backup is true
+
+  Windows VSS backup is enabled but no EC2 instances are selected for backup. Either disable windows_vss_backup or include EC2 instances in your backup selection.
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.0 |
+| aws | >= 4.0 |
+
+## Notes
+
+- Windows VSS backup is only applicable to Windows EC2 instances
+- When enabled, at least one EC2 instance must be included in the backup selection
+- This can be done via direct ARN references or tag-based selection 

--- a/examples/simple_plan_windows_vss_backup/main.tf
+++ b/examples/simple_plan_windows_vss_backup/main.tf
@@ -1,0 +1,58 @@
+# Windows VSS Backup Example
+# This example demonstrates the Windows VSS backup functionality
+# and validation requirements for EC2 instances
+
+module "aws_backup_windows_vss" {
+  source = "../.."
+
+  # Basic configuration
+  vault_name = "windows_vss_backup_vault"
+  plan_name  = "windows_vss_backup_plan"
+
+  # Enable Windows VSS backup (Windows Volume Shadow Copy Service)
+  windows_vss_backup = true
+
+  # Add a simple rule
+  rule_name         = "daily_backup"
+  rule_schedule     = "cron(0 12 * * ? *)"
+  rule_start_window = 60
+
+  # OPTION 1: Working configuration with EC2 instances
+  # Windows VSS backup requires at least one EC2 instance in the selection
+  selection_name = "windows_ec2_selection"
+  selection_resources = [
+    # Include an EC2 instance to satisfy the validation
+    "arn:aws:ec2:us-west-2:123456789012:instance/i-1234567890abcdef0",
+    
+    # You can also include other resources
+    "arn:aws:dynamodb:us-west-2:123456789012:table/my-table"
+  ]
+
+  # OPTION 2: Error case - uncomment to test validation error
+  # Comment out the above selection_resources and uncomment these lines
+  /*
+  selection_name = "windows_ec2_selection"
+  selection_resources = [
+    # No EC2 instances here - will trigger the validation error
+    "arn:aws:dynamodb:us-west-2:123456789012:table/my-table"
+  ]
+  */
+
+  # Additional example with tag-based selection
+  # This will select all EC2 instances with the specified tag
+  selections = [
+    {
+      name = "tag_based_selection"
+      selection_tag = {
+        type  = "STRINGEQUALS"
+        key   = "Backup"
+        value = "windows-vss"
+      }
+    }
+  ]
+
+  tags = {
+    Environment = "test"
+    Purpose     = "Windows VSS Backup Example"
+  }
+} 

--- a/examples/simple_plan_windows_vss_backup/provider.tf
+++ b/examples/simple_plan_windows_vss_backup/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = var.env["region"]
+  profile = var.env["profile"]
+}

--- a/examples/simple_plan_windows_vss_backup/terraform.tfvars
+++ b/examples/simple_plan_windows_vss_backup/terraform.tfvars
@@ -1,0 +1,4 @@
+env = {
+  region  = "us-east-1"
+  profile = "default"
+}

--- a/examples/simple_plan_windows_vss_backup/variables.tf
+++ b/examples/simple_plan_windows_vss_backup/variables.tf
@@ -1,0 +1,9 @@
+variable "env" {
+  description = "Environment configuration map. Used to define environment-specific parameters like tags, resource names, and other settings"
+  type        = map(any)
+  default = {
+    Environment = "prod"
+    Owner       = "devops"
+    Terraform   = true
+  }
+}

--- a/examples/simple_plan_windows_vss_backup/versions.tf
+++ b/examples/simple_plan_windows_vss_backup/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+  }
+} 

--- a/main.tf
+++ b/main.tf
@@ -89,8 +89,8 @@ resource "aws_backup_plan" "ab_plan" {
 
   lifecycle {
     precondition {
-      condition     = !var.windows_vss_backup || can(regex(".*EC2.*", join(",", local.selection_resources)))
-      error_message = "Windows VSS backup is enabled but no EC2 instances are selected for backup."
+      condition     = !var.windows_vss_backup || (length(local.selection_resources) > 0 && can(regex(".*EC2.*", join(",", local.selection_resources))))
+      error_message = "Windows VSS backup is enabled but no EC2 instances are selected for backup. Either disable windows_vss_backup or include EC2 instances in your backup selection."
     }
 
     # Add lifecycle validations at the plan level


### PR DESCRIPTION
- Updated the validation logic in the AWS Backup plan to ensure at least one EC2 instance is selected when Windows VSS backup is enabled.
- Added a new example configuration demonstrating the Windows VSS backup functionality, including proper setup and error case testing.
- Created supporting files for the example, including provider, variables, and README documentation.