### PR TITLE
fix: simplify recovery point tags assignment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ resource "aws_backup_plan" "ab_plan" {
       start_window             = try(rule.value.start_window, null)
       completion_window        = try(rule.value.completion_window, null)
       enable_continuous_backup = try(rule.value.enable_continuous_backup, null)
-      recovery_point_tags      = length(try(rule.value.recovery_point_tags, {})) == 0 ? var.tags : rule.value.recovery_point_tags
+      recovery_point_tags      = coalesce(rule.value.recovery_point_tags, var.tags)
 
       # Lifecycle
       dynamic "lifecycle" {


### PR DESCRIPTION
This PR fixes issue #109 where an error occurs when `recovery_point_tags` is not set in the rules block. The error was caused by attempting to use the `length()` function on a potentially null value, which Terraform doesn't allow even when wrapped in `try()`.

### Changes

- Replace `length(try(rule.value.recovery_point_tags, {})) == 0 ? var.tags : rule.value.recovery_point_tags` with `coalesce(rule.value.recovery_point_tags, var.tags)`
- This change maintains the same functionality but handles null values properly using Terraform's built-in `coalesce` function

Thanks @Edward-Ireson