### PR TITLE
chore: update release-please to include tag format versioning

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -7,12 +7,14 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "include-v-in-tag": false,
+      "tag-format": "${version}",
       "extra-files": []
     }
   },
   "release-search-depth": 10,
   "include-component-in-tag": false,
   "include-v-in-tag": false,
+  "tag-format": "${version}",
   "release-title-pattern": "${package-name} ${version}",
   "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
   "changelog-types": [


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/.release-please-config.json` file. The change adds a new configuration option to specify the format of the release tags.

Configuration changes:

* [`.github/.release-please-config.json`](diffhunk://#diff-654b5d1c6182210bb04674196ce31e01a13238f90a807f1a53c2e977687234c1R10-R17): Added the `tag-format` configuration option to specify the format of the release tags.