### PR TITLE
chore: Remove release title pattern from release-please configuration

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -15,7 +15,6 @@
   "include-component-in-tag": false,
   "include-v-in-tag": false,
   "tag-format": "${version}",
-  "release-title-pattern": "${package-name} ${version}",
   "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
   "changelog-types": [
     {"type": "feat", "section": "Added", "hidden": false},


### PR DESCRIPTION
This pull request includes a change to the `.github/.release-please-config.json` file to update the release title pattern.

* [`.github/.release-please-config.json`](diffhunk://#diff-654b5d1c6182210bb04674196ce31e01a13238f90a807f1a53c2e977687234c1L18): Removed the `release-title-pattern` configuration to streamline the release process.