### PR TITLE
fix: Add missing cold_storage_after validations for plans and rules variables

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -167,55 +167,7 @@ variable "plans" {
     error_message = "Plans validation failed: completion_window must be at least 60 minutes longer than start_window."
   }
 
-  validation {
-    condition = alltrue([
-      for plan_name, plan in var.plans : alltrue([
-        for rule in plan.rules : alltrue([
-          # Validate main rule lifecycle cold_storage_after
-          (try(rule.lifecycle.cold_storage_after, null) == null ||
-            (try(rule.lifecycle.cold_storage_after, null) != null && (
-              try(rule.lifecycle.cold_storage_after, 0) == 0 ||
-              try(rule.lifecycle.cold_storage_after, 0) >= 30
-          ))),
-          # Validate copy actions lifecycle cold_storage_after
-          alltrue([
-            for copy_action in try(rule.copy_actions, []) :
-            (try(copy_action.lifecycle.cold_storage_after, null) == null ||
-              (try(copy_action.lifecycle.cold_storage_after, null) != null && (
-                try(copy_action.lifecycle.cold_storage_after, 0) == 0 ||
-                try(copy_action.lifecycle.cold_storage_after, 0) >= 30
-            )))
-          ])
-        ])
-      ])
-    ])
-    error_message = "Plans validation failed: cold_storage_after must be 0 (disabled) or at least 30 days (AWS minimum requirement). To disable cold storage, omit the cold_storage_after parameter entirely or set to 0. This applies to both main rule lifecycle and copy action lifecycle."
-  }
 
-  validation {
-    condition = alltrue([
-      for plan_name, plan in var.plans : alltrue([
-        for rule in plan.rules : alltrue([
-          # Validate main rule lifecycle cold_storage_after <= delete_after relationship
-          (try(rule.lifecycle.cold_storage_after, null) == null ||
-            try(rule.lifecycle.delete_after, null) == null ||
-            (try(rule.lifecycle.cold_storage_after, null) != null &&
-              try(rule.lifecycle.delete_after, null) != null &&
-          try(rule.lifecycle.cold_storage_after, 0) <= try(rule.lifecycle.delete_after, 90))),
-          # Validate copy actions lifecycle cold_storage_after <= delete_after relationship
-          alltrue([
-            for copy_action in try(rule.copy_actions, []) :
-            (try(copy_action.lifecycle.cold_storage_after, null) == null ||
-              try(copy_action.lifecycle.delete_after, null) == null ||
-              (try(copy_action.lifecycle.cold_storage_after, null) != null &&
-                try(copy_action.lifecycle.delete_after, null) != null &&
-            try(copy_action.lifecycle.cold_storage_after, 0) <= try(copy_action.lifecycle.delete_after, 90)))
-          ])
-        ])
-      ])
-    ])
-    error_message = "Plans validation failed: cold_storage_after must be ≤ delete_after. This applies to both main rule lifecycle and copy action lifecycle."
-  }
 
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -303,51 +303,7 @@ variable "rules" {
     error_message = "Lifecycle validation failed: delete_after must be ≥ 1 day."
   }
 
-  validation {
-    condition = alltrue([
-      for rule in var.rules : alltrue([
-        # Validate main rule lifecycle cold_storage_after
-        (try(rule.lifecycle.cold_storage_after, null) == null ||
-          (try(rule.lifecycle.cold_storage_after, null) != null && (
-            try(rule.lifecycle.cold_storage_after, 0) == 0 ||
-            try(rule.lifecycle.cold_storage_after, 0) >= 30
-        ))),
-        # Validate copy actions lifecycle cold_storage_after
-        alltrue([
-          for copy_action in try(rule.copy_actions, []) :
-          (try(copy_action.lifecycle.cold_storage_after, null) == null ||
-            (try(copy_action.lifecycle.cold_storage_after, null) != null && (
-              try(copy_action.lifecycle.cold_storage_after, 0) == 0 ||
-              try(copy_action.lifecycle.cold_storage_after, 0) >= 30
-          )))
-        ])
-      ])
-    ])
-    error_message = "Rules validation failed: cold_storage_after must be 0 (disabled) or at least 30 days (AWS minimum requirement). To disable cold storage, omit the cold_storage_after parameter entirely or set to 0. This applies to both main rule lifecycle and copy action lifecycle."
-  }
 
-  validation {
-    condition = alltrue([
-      for rule in var.rules : alltrue([
-        # Validate main rule lifecycle cold_storage_after <= delete_after relationship
-        (try(rule.lifecycle.cold_storage_after, null) == null ||
-          try(rule.lifecycle.delete_after, null) == null ||
-          (try(rule.lifecycle.cold_storage_after, null) != null &&
-            try(rule.lifecycle.delete_after, null) != null &&
-        try(rule.lifecycle.cold_storage_after, 0) <= try(rule.lifecycle.delete_after, 90))),
-        # Validate copy actions lifecycle cold_storage_after <= delete_after relationship
-        alltrue([
-          for copy_action in try(rule.copy_actions, []) :
-          (try(copy_action.lifecycle.cold_storage_after, null) == null ||
-            try(copy_action.lifecycle.delete_after, null) == null ||
-            (try(copy_action.lifecycle.cold_storage_after, null) != null &&
-              try(copy_action.lifecycle.delete_after, null) != null &&
-          try(copy_action.lifecycle.cold_storage_after, 0) <= try(copy_action.lifecycle.delete_after, 90)))
-        ])
-      ])
-    ])
-    error_message = "Rules validation failed: cold_storage_after must be ≤ delete_after. This applies to both main rule lifecycle and copy action lifecycle."
-  }
 
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -167,6 +167,48 @@ variable "plans" {
     error_message = "Plans validation failed: completion_window must be at least 60 minutes longer than start_window."
   }
 
+  validation {
+    condition = alltrue([
+      for plan_name, plan in var.plans : alltrue([
+        for rule in plan.rules : alltrue([
+          # Validate main rule lifecycle cold_storage_after
+          (try(rule.lifecycle.cold_storage_after, null) == null ||
+            try(rule.lifecycle.cold_storage_after, 0) == 0 ||
+            try(rule.lifecycle.cold_storage_after, 0) >= 30),
+          # Validate copy actions lifecycle cold_storage_after
+          alltrue([
+            for copy_action in try(rule.copy_actions, []) :
+            (try(copy_action.lifecycle.cold_storage_after, null) == null ||
+              try(copy_action.lifecycle.cold_storage_after, 0) == 0 ||
+              try(copy_action.lifecycle.cold_storage_after, 0) >= 30)
+          ])
+        ])
+      ])
+    ])
+    error_message = "Plans validation failed: cold_storage_after must be 0 (disabled) or at least 30 days (AWS minimum requirement). To disable cold storage, omit the cold_storage_after parameter entirely or set to 0. This applies to both main rule lifecycle and copy action lifecycle."
+  }
+
+  validation {
+    condition = alltrue([
+      for plan_name, plan in var.plans : alltrue([
+        for rule in plan.rules : alltrue([
+          # Validate main rule lifecycle cold_storage_after <= delete_after relationship
+          (try(rule.lifecycle.cold_storage_after, null) == null ||
+            try(rule.lifecycle.delete_after, null) == null ||
+            try(rule.lifecycle.cold_storage_after, 0) <= try(rule.lifecycle.delete_after, 90)),
+          # Validate copy actions lifecycle cold_storage_after <= delete_after relationship
+          alltrue([
+            for copy_action in try(rule.copy_actions, []) :
+            (try(copy_action.lifecycle.cold_storage_after, null) == null ||
+              try(copy_action.lifecycle.delete_after, null) == null ||
+              try(copy_action.lifecycle.cold_storage_after, 0) <= try(copy_action.lifecycle.delete_after, 90))
+          ])
+        ])
+      ])
+    ])
+    error_message = "Plans validation failed: cold_storage_after must be ≤ delete_after. This applies to both main rule lifecycle and copy action lifecycle."
+  }
+
 }
 
 # Default rule
@@ -299,6 +341,44 @@ variable "rules" {
       try(rule.lifecycle.delete_after, 90) >= 1
     ])
     error_message = "Lifecycle validation failed: delete_after must be ≥ 1 day."
+  }
+
+  validation {
+    condition = alltrue([
+      for rule in var.rules : alltrue([
+        # Validate main rule lifecycle cold_storage_after
+        (try(rule.lifecycle.cold_storage_after, null) == null ||
+          try(rule.lifecycle.cold_storage_after, 0) == 0 ||
+          try(rule.lifecycle.cold_storage_after, 0) >= 30),
+        # Validate copy actions lifecycle cold_storage_after
+        alltrue([
+          for copy_action in try(rule.copy_actions, []) :
+          (try(copy_action.lifecycle.cold_storage_after, null) == null ||
+            try(copy_action.lifecycle.cold_storage_after, 0) == 0 ||
+            try(copy_action.lifecycle.cold_storage_after, 0) >= 30)
+        ])
+      ])
+    ])
+    error_message = "Rules validation failed: cold_storage_after must be 0 (disabled) or at least 30 days (AWS minimum requirement). To disable cold storage, omit the cold_storage_after parameter entirely or set to 0. This applies to both main rule lifecycle and copy action lifecycle."
+  }
+
+  validation {
+    condition = alltrue([
+      for rule in var.rules : alltrue([
+        # Validate main rule lifecycle cold_storage_after <= delete_after relationship
+        (try(rule.lifecycle.cold_storage_after, null) == null ||
+          try(rule.lifecycle.delete_after, null) == null ||
+          try(rule.lifecycle.cold_storage_after, 0) <= try(rule.lifecycle.delete_after, 90)),
+        # Validate copy actions lifecycle cold_storage_after <= delete_after relationship
+        alltrue([
+          for copy_action in try(rule.copy_actions, []) :
+          (try(copy_action.lifecycle.cold_storage_after, null) == null ||
+            try(copy_action.lifecycle.delete_after, null) == null ||
+            try(copy_action.lifecycle.cold_storage_after, 0) <= try(copy_action.lifecycle.delete_after, 90))
+        ])
+      ])
+    ])
+    error_message = "Rules validation failed: cold_storage_after must be ≤ delete_after. This applies to both main rule lifecycle and copy action lifecycle."
   }
 
 }

--- a/variables.tf
+++ b/variables.tf
@@ -173,14 +173,18 @@ variable "plans" {
         for rule in plan.rules : alltrue([
           # Validate main rule lifecycle cold_storage_after
           (try(rule.lifecycle.cold_storage_after, null) == null ||
-            try(rule.lifecycle.cold_storage_after, 0) == 0 ||
-            try(rule.lifecycle.cold_storage_after, 0) >= 30),
+            (try(rule.lifecycle.cold_storage_after, null) != null && (
+              try(rule.lifecycle.cold_storage_after, 0) == 0 ||
+              try(rule.lifecycle.cold_storage_after, 0) >= 30
+          ))),
           # Validate copy actions lifecycle cold_storage_after
           alltrue([
             for copy_action in try(rule.copy_actions, []) :
             (try(copy_action.lifecycle.cold_storage_after, null) == null ||
-              try(copy_action.lifecycle.cold_storage_after, 0) == 0 ||
-              try(copy_action.lifecycle.cold_storage_after, 0) >= 30)
+              (try(copy_action.lifecycle.cold_storage_after, null) != null && (
+                try(copy_action.lifecycle.cold_storage_after, 0) == 0 ||
+                try(copy_action.lifecycle.cold_storage_after, 0) >= 30
+            )))
           ])
         ])
       ])
@@ -195,13 +199,13 @@ variable "plans" {
           # Validate main rule lifecycle cold_storage_after <= delete_after relationship
           (try(rule.lifecycle.cold_storage_after, null) == null ||
             try(rule.lifecycle.delete_after, null) == null ||
-            try(rule.lifecycle.cold_storage_after, 0) <= try(rule.lifecycle.delete_after, 90)),
+          try(rule.lifecycle.cold_storage_after, 0) <= try(rule.lifecycle.delete_after, 90)),
           # Validate copy actions lifecycle cold_storage_after <= delete_after relationship
           alltrue([
             for copy_action in try(rule.copy_actions, []) :
             (try(copy_action.lifecycle.cold_storage_after, null) == null ||
               try(copy_action.lifecycle.delete_after, null) == null ||
-              try(copy_action.lifecycle.cold_storage_after, 0) <= try(copy_action.lifecycle.delete_after, 90))
+            try(copy_action.lifecycle.cold_storage_after, 0) <= try(copy_action.lifecycle.delete_after, 90))
           ])
         ])
       ])
@@ -348,14 +352,18 @@ variable "rules" {
       for rule in var.rules : alltrue([
         # Validate main rule lifecycle cold_storage_after
         (try(rule.lifecycle.cold_storage_after, null) == null ||
-          try(rule.lifecycle.cold_storage_after, 0) == 0 ||
-          try(rule.lifecycle.cold_storage_after, 0) >= 30),
+          (try(rule.lifecycle.cold_storage_after, null) != null && (
+            try(rule.lifecycle.cold_storage_after, 0) == 0 ||
+            try(rule.lifecycle.cold_storage_after, 0) >= 30
+        ))),
         # Validate copy actions lifecycle cold_storage_after
         alltrue([
           for copy_action in try(rule.copy_actions, []) :
           (try(copy_action.lifecycle.cold_storage_after, null) == null ||
-            try(copy_action.lifecycle.cold_storage_after, 0) == 0 ||
-            try(copy_action.lifecycle.cold_storage_after, 0) >= 30)
+            (try(copy_action.lifecycle.cold_storage_after, null) != null && (
+              try(copy_action.lifecycle.cold_storage_after, 0) == 0 ||
+              try(copy_action.lifecycle.cold_storage_after, 0) >= 30
+          )))
         ])
       ])
     ])
@@ -368,13 +376,13 @@ variable "rules" {
         # Validate main rule lifecycle cold_storage_after <= delete_after relationship
         (try(rule.lifecycle.cold_storage_after, null) == null ||
           try(rule.lifecycle.delete_after, null) == null ||
-          try(rule.lifecycle.cold_storage_after, 0) <= try(rule.lifecycle.delete_after, 90)),
+        try(rule.lifecycle.cold_storage_after, 0) <= try(rule.lifecycle.delete_after, 90)),
         # Validate copy actions lifecycle cold_storage_after <= delete_after relationship
         alltrue([
           for copy_action in try(rule.copy_actions, []) :
           (try(copy_action.lifecycle.cold_storage_after, null) == null ||
             try(copy_action.lifecycle.delete_after, null) == null ||
-            try(copy_action.lifecycle.cold_storage_after, 0) <= try(copy_action.lifecycle.delete_after, 90))
+          try(copy_action.lifecycle.cold_storage_after, 0) <= try(copy_action.lifecycle.delete_after, 90))
         ])
       ])
     ])

--- a/variables.tf
+++ b/variables.tf
@@ -199,13 +199,17 @@ variable "plans" {
           # Validate main rule lifecycle cold_storage_after <= delete_after relationship
           (try(rule.lifecycle.cold_storage_after, null) == null ||
             try(rule.lifecycle.delete_after, null) == null ||
-          try(rule.lifecycle.cold_storage_after, 0) <= try(rule.lifecycle.delete_after, 90)),
+            (try(rule.lifecycle.cold_storage_after, null) != null &&
+              try(rule.lifecycle.delete_after, null) != null &&
+          try(rule.lifecycle.cold_storage_after, 0) <= try(rule.lifecycle.delete_after, 90))),
           # Validate copy actions lifecycle cold_storage_after <= delete_after relationship
           alltrue([
             for copy_action in try(rule.copy_actions, []) :
             (try(copy_action.lifecycle.cold_storage_after, null) == null ||
               try(copy_action.lifecycle.delete_after, null) == null ||
-            try(copy_action.lifecycle.cold_storage_after, 0) <= try(copy_action.lifecycle.delete_after, 90))
+              (try(copy_action.lifecycle.cold_storage_after, null) != null &&
+                try(copy_action.lifecycle.delete_after, null) != null &&
+            try(copy_action.lifecycle.cold_storage_after, 0) <= try(copy_action.lifecycle.delete_after, 90)))
           ])
         ])
       ])
@@ -376,13 +380,17 @@ variable "rules" {
         # Validate main rule lifecycle cold_storage_after <= delete_after relationship
         (try(rule.lifecycle.cold_storage_after, null) == null ||
           try(rule.lifecycle.delete_after, null) == null ||
-        try(rule.lifecycle.cold_storage_after, 0) <= try(rule.lifecycle.delete_after, 90)),
+          (try(rule.lifecycle.cold_storage_after, null) != null &&
+            try(rule.lifecycle.delete_after, null) != null &&
+        try(rule.lifecycle.cold_storage_after, 0) <= try(rule.lifecycle.delete_after, 90))),
         # Validate copy actions lifecycle cold_storage_after <= delete_after relationship
         alltrue([
           for copy_action in try(rule.copy_actions, []) :
           (try(copy_action.lifecycle.cold_storage_after, null) == null ||
             try(copy_action.lifecycle.delete_after, null) == null ||
-          try(copy_action.lifecycle.cold_storage_after, 0) <= try(copy_action.lifecycle.delete_after, 90))
+            (try(copy_action.lifecycle.cold_storage_after, null) != null &&
+              try(copy_action.lifecycle.delete_after, null) != null &&
+          try(copy_action.lifecycle.cold_storage_after, 0) <= try(copy_action.lifecycle.delete_after, 90)))
         ])
       ])
     ])


### PR DESCRIPTION
## Summary
Fixes #161 by adding comprehensive AWS Backup cold storage validation to prevent runtime deployment failures.

## Changes Made
- ✅ **Added cold_storage_after validation for `plans` variable** (0 or ≥30 days)
- ✅ **Added cold_storage_after validation for `rules` variable** (0 or ≥30 days)  
- ✅ **Added cold_storage_after ≤ delete_after relationship validation**
- ✅ **Applied validations to both main lifecycle and copy_actions lifecycle**
- ✅ **Prevent runtime AWS API failures from invalid 1-29 day values**

## Problem Solved
AWS Backup requires cold storage transitions to be either:
- **`0`** (disabled) or **`null`** (omitted) to disable cold storage
- **`≥ 30 days`** (AWS minimum requirement)
- **Values 1-29 days are INVALID** and cause API errors

Previously, the `plans` and `rules` variables were missing these validations, allowing users to configure invalid values that would pass Terraform validation but fail at the AWS API level.

## Test Plan
- [x] Terraform configuration validates successfully
- [x] Added comprehensive validation rules matching existing `backup_policies` validation
- [x] Validation covers both main rule lifecycle and copy actions lifecycle
- [x] Proper error messages guide users to correct configurations

## Validation Examples

### ✅ Valid Configurations
```hcl
# Disabled cold storage
lifecycle = {
  delete_after = 90
  # cold_storage_after omitted
}

# Valid cold storage  
lifecycle = {
  cold_storage_after = 30  # AWS minimum
  delete_after = 365
}
```

### ❌ Invalid Configurations (Now Caught by Validation)
```hcl
# These will now fail Terraform validation before reaching AWS API
lifecycle = {
  cold_storage_after = 15  # Invalid - below 30 day minimum  
  delete_after = 90
}

lifecycle = {
  cold_storage_after = 90  # Invalid - exceeds delete_after
  delete_after = 30
}
```

🤖 Generated with [Claude Code](https://claude.ai/code)