### PR TITLE
fix: update Go version to 1.23 and configure Renovate to prevent pre-release versions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25'
+        go-version: '1.23'
 
     - name: Run Go vulnerability scan
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25'
+        go-version: '1.23'
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3
@@ -60,7 +60,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25'
+        go-version: '1.23'
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3
@@ -104,7 +104,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25'
+        go-version: '1.23'
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3

--- a/renovate.json
+++ b/renovate.json
@@ -38,7 +38,20 @@
       "enabled": true,
       "schedule": [
         "before 9am on monday"
-      ]
+      ],
+      "ignoreUnstable": true
+    },
+    {
+      "matchDatasources": ["golang-version"],
+      "ignoreUnstable": true,
+      "enabled": true
+    },
+    {
+      "matchDepTypes": ["action"],
+      "matchPackageNames": ["actions/setup-go"],
+      "extractVersion": "^v(?<version>.*)$",
+      "versioning": "go-mod-directive",
+      "ignoreUnstable": true
     },
     {
       "matchDatasources": [


### PR DESCRIPTION
## Summary
- Fixed Go version from invalid 1.25 to stable 1.23 in test.yml and security.yml workflows
- Added Renovate configuration to prevent future pre-release Go version suggestions

## Changes
- Updated `.github/workflows/test.yml` to use Go version 1.23 (was using non-existent 1.25)
- Updated `.github/workflows/security.yml` to use Go version 1.23 (was using non-existent 1.25)
- Enhanced `renovate.json` with rules to:
  - Ignore unstable golang-version datasource releases
  - Prevent unstable versions for actions/setup-go action
  - Add ignoreUnstable to existing Go datasource rule

## Test Plan
- [ ] GitHub Actions tests should now pass with valid Go version
- [ ] Security scans should complete successfully
- [ ] Renovate will no longer suggest pre-release Go versions