### PR TITLE
fix: add id-token write permission for OIDC authentication

### DIFF
--- a/.github/workflows/feature-discovery.yml
+++ b/.github/workflows/feature-discovery.yml
@@ -33,6 +33,7 @@ jobs:
       contents: read
       issues: write
       actions: read
+      id-token: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
Fixes the AWS Backup Feature Discovery workflow failure by adding the required `id-token: write` permission for OIDC authentication.

## Problem
The workflow was failing at the "Run Claude Code Feature Discovery" step with the error:
```
Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
Did you remember to add id-token: write to your workflow permissions?
```

## Solution
Added `id-token: write` to the permissions section of the workflow file `.github/workflows/feature-discovery.yml`.

## Changes
- ✅ Added `id-token: write` permission to workflow
- ✅ Pre-commit checks passed
- ✅ No breaking changes

## Test plan
- [ ] Workflow should now run successfully without OIDC authentication errors
- [ ] Feature discovery process should complete as expected

Closes #224