### PR TITLE
fix: replace TERRAFORM_AUTOMATION_TOKEN with CLAUDE_ISSUE_TOKEN for MCP connectivity

### DIFF
--- a/.github/workflows/feature-discovery.yml
+++ b/.github/workflows/feature-discovery.yml
@@ -75,11 +75,11 @@ jobs:
         uses: anthropics/claude-code-action@beta
         env:
           CLAUDE_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.TERRAFORM_AUTOMATION_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CLAUDE_ISSUE_TOKEN }}
         with:
           claude_code_oauth_token: ${{ env.CLAUDE_TOKEN }}
           mode: agent
-          github_token: ${{ secrets.TERRAFORM_AUTOMATION_TOKEN }}
+          github_token: ${{ secrets.CLAUDE_ISSUE_TOKEN }}
 
           # MCP Configuration for Terraform and Context7 documentation access
           mcp_config: |


### PR DESCRIPTION
## Summary
Fixes MCP server connectivity issues by switching from `TERRAFORM_AUTOMATION_TOKEN` to `CLAUDE_ISSUE_TOKEN`.

## Problem
The feature discovery workflow was failing because the Terraform MCP server couldn't connect:
```json
{
  "name": "terraform", 
  "status": "failed"
}
```

This prevented the workflow from:
- Fetching AWS provider documentation
- Discovering new Backup features  
- Creating auto-discovered issues

## Solution
Changed token configuration to match the **working** ECR repository setup:

### Changes Made:
```yaml
env:
- GITHUB_TOKEN: ${{ secrets.TERRAFORM_AUTOMATION_TOKEN }}
+ GITHUB_TOKEN: ${{ secrets.CLAUDE_ISSUE_TOKEN }}

with:
- github_token: ${{ secrets.TERRAFORM_AUTOMATION_TOKEN }}
+ github_token: ${{ secrets.CLAUDE_ISSUE_TOKEN }}
```

## Evidence This Will Work
The ECR repository uses `CLAUDE_ISSUE_TOKEN` and successfully:
- ✅ Connects both Terraform and Context7 MCP servers
- ✅ Creates auto-discovered issues (#159, #158, #157, #156)
- ✅ Runs feature discovery regularly with 26 successful runs

## Test Plan
After merge:
- [ ] Test workflow on master branch
- [ ] Verify Terraform MCP server shows `"status": "connected"`
- [ ] Confirm issues are created for any discovered features
- [ ] Validate feature tracker is properly updated

This should resolve the core MCP connectivity issue and enable full feature discovery functionality.