### PR TITLE
fix: Use official HashiCorp Terraform MCP server

### DIFF
--- a/.github/workflows/feature-discovery.yml
+++ b/.github/workflows/feature-discovery.yml
@@ -118,10 +118,12 @@ jobs:
             {
               "mcpServers": {
                 "terraform": {
-                  "command": "npx",
+                  "command": "docker",
                   "args": [
-                    "-y",
-                    "@modelcontextprotocol/server-terraform@latest"
+                    "run",
+                    "-i",
+                    "--rm",
+                    "hashicorp/terraform-mcp-server"
                   ]
                 },
                 "context7": {


### PR DESCRIPTION
## 🔧 Fix MCP Server Connectivity Issues

### Problem
The AWS Backup Feature Discovery workflow was failing due to MCP server connectivity issues:
- Using non-existent npm package `@modelcontextprotocol/server-terraform@latest`
- Terraform MCP server status: **failed**
- Only Context7 MCP server was working

### Solution
- ✅ Replace with official HashiCorp Terraform MCP server
- ✅ Use Docker-based deployment: `hashicorp/terraform-mcp-server`
- ✅ Keep working Context7 MCP server unchanged
- ✅ Validated Docker support in GitHub Actions

### Validation Results
- ✅ **MCP Server Connectivity**: Fixed - Terraform server now connects successfully
- ✅ **Feature Discovery**: Working - Claude Code executed successfully for 3+ minutes
- ✅ **Docker Support**: Confirmed available in GitHub Actions (Docker 28.3.2)
- ✅ **Workflow Execution**: Main discovery step now succeeds

### Testing
- Workflow run [#17364625038](https://github.com/lgallard/terraform-aws-backup/actions/runs/17364625038) shows:
  - ✅ "Run Claude Code Feature Discovery": SUCCESS (3+ minutes execution)
  - ✅ MCP servers connected properly
  - ✅ Feature tracker updated successfully

### Remaining Minor Issue
- Git push permission issue (separate from MCP connectivity)
- Will be resolved when merged to master

**Resolves: #224**

### Files Changed
- `.github/workflows/feature-discovery.yml`: Updated MCP server configuration