### PR TITLE
fix: Update Terraform MCP server tool permissions

### DIFF
--- a/.github/workflows/feature-discovery.yml
+++ b/.github/workflows/feature-discovery.yml
@@ -138,10 +138,14 @@ jobs:
 
           # Allow necessary tools for feature discovery
           allowed_tools: |
-            mcp__terraform-server__getProviderDocs
-            mcp__terraform-server__resolveProviderDocID
-            mcp__terraform-server__searchModules
-            mcp__terraform-server__moduleDetails
+            mcp__terraform__search_providers
+            mcp__terraform__get_provider_details
+            mcp__terraform__get_latest_provider_version
+            mcp__terraform__search_modules
+            mcp__terraform__get_module_details
+            mcp__terraform__get_latest_module_version
+            mcp__terraform__search_policies
+            mcp__terraform__get_policy_details
             mcp__context7__resolve-library-id
             mcp__context7__get-library-docs
             Bash(git diff)


### PR DESCRIPTION
## Fix Tool Permissions for HashiCorp Terraform MCP Server

### Problem Identified
After fixing MCP connectivity, workflow failing due to tool permission mismatch:
- MCP Connectivity: Both terraform and context7 servers connecting successfully  
- Tool Permissions: Claude trying to use mcp__terraform__get_latest_provider_version but only mcp__terraform-server__* tools were allowed

### Root Cause
HashiCorp Terraform MCP server uses different tool naming pattern than expected:
- HashiCorp Server Tools: mcp__terraform__search_providers, mcp__terraform__get_provider_details, etc.
- Previous Workflow: Expected mcp__terraform-server__getProviderDocs, mcp__terraform-server__resolveProviderDocID, etc.

### Solution
Updated allowed_tools to match HashiCorp MCP server actual tool names for providers, modules, and policies toolsets.

### Evidence
MCP servers now show connected status but tool permission errors prevent execution.

Resolves: #224