### PR TITLE
fix: add pull-requests write permission for automated PR creation

### DIFF
--- a/.github/workflows/feature-discovery.yml
+++ b/.github/workflows/feature-discovery.yml
@@ -32,6 +32,7 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write
       actions: read
       id-token: write
 


### PR DESCRIPTION
## Problem
The AWS Backup Feature Discovery workflow is failing at the PR creation step with:
```
pull request create failed: GraphQL: Resource not accessible by integration (createPullRequest)
```

This occurs because the default `GITHUB_TOKEN` lacks `pull-requests: write` permission.

## Solution
Added `pull-requests: write` permission to the existing job permissions block.

**Before:**
```yaml
permissions:
  contents: write
  issues: write
  actions: read
  id-token: write
```

**After:**
```yaml
permissions:
  contents: write
  issues: write
  pull-requests: write  # ← Added this line
  actions: read
  id-token: write
```

## Impact
- ✅ Enables automated PR creation for feature tracker updates
- ✅ Completes the end-to-end automation workflow
- ✅ No more manual intervention required for tracker database updates
- ✅ Maintains security through proper GitHub token permissions

## Testing
The workflow is already successfully:
- Creating GitHub issues for discovered features (#250, #251)
- Updating tracker database and committing to feature branches
- Bypassing protected branch restrictions

This fix will complete the automation by enabling PR creation.