### PR TITLE
feat: implement smart PR creation for feature tracker updates

### DIFF
--- a/.github/workflows/feature-discovery.yml
+++ b/.github/workflows/feature-discovery.yml
@@ -606,6 +606,9 @@ jobs:
           LOCKFILE="/tmp/feature-tracker.lock"
           TRACKER_FILE=".github/feature-tracker/backup-features.json"
           TEMP_FILE="${TRACKER_FILE}.tmp"
+          
+          # Get issues created count from previous step
+          ISSUES_CREATED="${{ steps.create-issues-from-json.outputs.issues_created || '0' }}"
 
           # Acquire lock with timeout
           exec 200>"$LOCKFILE"
@@ -620,6 +623,17 @@ jobs:
             flock -u 200
             exit 0
           fi
+          
+          # Only create PR if new issues were created (meaningful changes)
+          if [ "$ISSUES_CREATED" -eq 0 ]; then
+            echo "📊 Tracker updated with metadata only - skipping PR creation"
+            echo "ℹ️  Scan completed but no new features discovered"
+            echo "ℹ️  Updated metadata: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+            flock -u 200
+            exit 0
+          fi
+          
+          echo "🚀 Creating PR for tracker updates with $ISSUES_CREATED new issues"
 
           # Validate JSON before committing
           if [ -f "$TRACKER_FILE" ]; then
@@ -715,6 +729,18 @@ jobs:
             echo "- ⏭️ **Issue Creation**: Skipped (no feature discovery or dry run)" >> $GITHUB_STEP_SUMMARY
           else
             echo "- ❌ **Issue Creation**: Failed or incomplete" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          # Tracker Update Status
+          if [ "${{ steps.claude-discovery.conclusion }}" = "success" ]; then
+            ISSUES_COUNT="${{ steps.create-issues-from-json.outputs.issues_created || '0' }}"
+            if [ "$ISSUES_COUNT" -gt 0 ]; then
+              echo "- ✅ **Tracker Updates**: Created PR for database updates" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "- 📊 **Tracker Updates**: Metadata updated (no PR needed)" >> $GITHUB_STEP_SUMMARY
+            fi
+          else
+            echo "- ⏭️ **Tracker Updates**: Skipped (discovery failed)" >> $GITHUB_STEP_SUMMARY
           fi
           echo "" >> $GITHUB_STEP_SUMMARY
 


### PR DESCRIPTION
## Problem
Current workflow creates PRs on every run, even when no new features are discovered. This leads to:
- PR spam from metadata-only updates
- Unnecessary maintenance overhead  
- Git history noise from frequent scan metadata commits

## Solution
Implement smart PR creation logic that only creates PRs for meaningful changes.

### Changes Made:

**Smart PR Logic:**
- Only create PRs when `ISSUES_CREATED > 0` (new features discovered)
- Skip PR creation for metadata-only updates
- Preserve scan logs in workflow output instead of creating noise commits

**Enhanced Logging:**
- Clear messaging when PR creation is skipped
- Informative workflow summary showing tracker update status
- Distinguish between "no changes" vs "metadata only" scenarios

**Logic Flow:**
```bash
if [ "$ISSUES_CREATED" -eq 0 ]; then
  echo "📊 Tracker updated with metadata only - skipping PR creation"  
  exit 0
fi
echo "🚀 Creating PR for tracker updates with $ISSUES_CREATED new issues"
```

## Benefits:
- ✅ Eliminates PR spam from scheduled runs with no discoveries
- ✅ Maintains automated issue creation functionality
- ✅ Reduces maintenance overhead for repository maintainers
- ✅ Creates PRs only when meaningful changes occur
- ✅ Preserves audit trail for scan execution in workflow logs

## Testing Plan:
- Test workflow with new feature discoveries (should create PR)
- Test workflow with no new features (should skip PR creation)  
- Verify workflow summary shows correct tracker update status