### PR TITLE
feat: add vault_name_validation_bypass variable to relax validation

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -9,10 +9,16 @@ variable "vault_name" {
   validation {
     condition = var.vault_name == null ? true : (
       can(regex("^[0-9A-Za-z-_]{2,50}$", var.vault_name)) &&
-      !can(regex("(?i)(test|temp|delete|remove|default)", var.vault_name)) # Prevent insecure naming patterns
+      (var.vault_name_validation_bypass || !can(regex("(?i)(test|temp|delete|remove|default)", var.vault_name))) # Prevent insecure naming patterns unless bypassed
     )
-    error_message = "The vault_name must be between 2 and 50 characters, contain only alphanumeric characters, hyphens, and underscores. Avoid using 'test', 'temp', 'delete', 'remove', or 'default' in names for security reasons."
+    error_message = "The vault_name must be between 2 and 50 characters, contain only alphanumeric characters, hyphens, and underscores. Avoid using 'test', 'temp', 'delete', 'remove', or 'default' in names for security reasons. Set vault_name_validation_bypass = true to disable this word validation for existing vaults."
   }
+}
+
+variable "vault_name_validation_bypass" {
+  description = "Bypass the vault name word validation (test, temp, delete, remove, default). Set to true for existing vaults with these words. Only disables word validation, format validation remains active."
+  type        = bool
+  default     = false
 }
 
 variable "vault_kms_key_arn" {


### PR DESCRIPTION
This PR addresses issue #292 by adding a bypass mechanism for vault name validation.

## Changes
- Added `vault_name_validation_bypass` variable to allow disabling word-based validation
- Modified vault_name validation logic to respect the bypass flag
- Maintains all format validation requirements
- Defaults to false for backward compatibility

## Benefits
- Allows users with existing vaults containing restricted words to upgrade
- Preserves security best practices by requiring explicit opt-out
- No breaking changes for existing users

Fixes #292

Generated with [Claude Code](https://claude.ai/code)