### PR TITLE
chore: add pre-commit workflow that skips terraform_docs in CI

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -40,7 +40,12 @@ jobs:
 
       - name: Install tflint
         run: |
-          curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+          TFLINT_VERSION="v0.54.0"
+          curl -sL "https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}/tflint_linux_amd64.zip" -o tflint.zip
+          unzip -q tflint.zip
+          sudo mv tflint /usr/local/bin/
+          rm tflint.zip
+          tflint --version
 
       - name: Install pre-commit
         run: |
@@ -65,8 +70,9 @@ jobs:
           if [ "${{ github.event_name }}" == "push" ]; then
             pre-commit run --all-files
           else
-            git fetch origin ${{ github.base_ref }}
-            CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.tf' '*.tfvars')
+            git fetch origin ${{ github.base_ref }} --depth=100
+            git status
+            CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.tf' '*.tfvars' '.pre-commit-config.yaml')
             if [ -n "$CHANGED_FILES" ]; then
               echo "Running pre-commit on changed files:"
               echo "$CHANGED_FILES"


### PR DESCRIPTION
## Summary

- Add dedicated pre-commit workflow with `SKIP: terraform_docs` environment variable
- Exclude `.md` files from paths filter (only triggers on `.tf`, `.tfvars`, `.pre-commit-config.yaml`)
- Rely on local pre-commit hooks for documentation generation

This eliminates environment parity issues between macOS and Linux that cause CI failures.

## Strategy

| Layer | Checks |
|-------|--------|
| **CI** | `terraform_fmt`, `terraform_validate`, `tflint`, file formatting |
| **Local** | Full pre-commit including `terraform_docs` |

## Reference

Based on implementation from [terraform-aws-ecrpublic](https://github.com/lgallard/terraform-aws-ecrpublic/blob/master/.github/workflows/pre-commit.yml)

Closes #316