### PR TITLE
Fix feature-discovery workflow boolean input defaults for scheduled runs

### DIFF
--- a/.github/workflows/feature-discovery.yml
+++ b/.github/workflows/feature-discovery.yml
@@ -76,9 +76,9 @@ jobs:
             exit 1
           fi
 
-          # Validate boolean inputs
-          DRY_RUN_INPUT="${{ inputs.dry_run }}"
-          FORCE_SCAN_INPUT="${{ inputs.force_scan }}"
+          # Validate boolean inputs (default to false for schedule triggers where inputs are empty)
+          DRY_RUN_INPUT="${{ inputs.dry_run || 'false' }}"
+          FORCE_SCAN_INPUT="${{ inputs.force_scan || 'false' }}"
 
           if [[ "$DRY_RUN_INPUT" != "true" && "$DRY_RUN_INPUT" != "false" ]]; then
             echo "::error::Invalid dry_run value: $DRY_RUN_INPUT"


### PR DESCRIPTION
## Summary
Fixed the feature-discovery workflow to properly handle boolean inputs when triggered by schedule events, where input parameters are not provided and default to empty strings.

## Key Changes
- Updated `dry_run` input to default to `'false'` when empty: `${{ inputs.dry_run || 'false' }}`
- Updated `force_scan` input to default to `'false'` when empty: `${{ inputs.force_scan || 'false' }}`
- Added clarifying comment explaining the default behavior for schedule triggers

## Implementation Details
When the workflow is triggered by a schedule event (as opposed to manual dispatch), the `inputs.dry_run` and `inputs.force_scan` parameters are not provided and evaluate to empty strings. This caused the subsequent boolean validation checks to fail. By providing explicit `'false'` defaults using the `||` operator, the workflow now correctly handles both manual and scheduled triggers without validation errors.

https://claude.ai/code/session_017SXfmbZDnAhbfd8umPzX5D