### PR TITLE
fix: Replace deprecated aws_region .id attribute with .region

### DIFF
--- a/examples/cross_account_vault_policy/main.tf
+++ b/examples/cross_account_vault_policy/main.tf
@@ -20,7 +20,7 @@ data "aws_iam_policy_document" "cross_account_vault_policy" {
       "backup:CopyIntoBackupVault"
     ]
 
-    resources = ["arn:aws:backup:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:backup-vault:${var.vault_name_prefix}-*"]
+    resources = ["arn:aws:backup:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:backup-vault:${var.vault_name_prefix}-*"]
 
     condition {
       test     = "StringEquals"
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "cross_account_vault_policy" {
       "backup:ListRecoveryPointsByBackupVault"
     ]
 
-    resources = ["arn:aws:backup:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:backup-vault:${var.vault_name_prefix}-*"]
+    resources = ["arn:aws:backup:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:backup-vault:${var.vault_name_prefix}-*"]
   }
 }
 
@@ -156,7 +156,7 @@ resource "aws_kms_key" "backup_vault_key" {
         Resource = "*"
         Condition = {
           StringEquals = {
-            "kms:ViaService" = "backup.${data.aws_region.current.name}.amazonaws.com"
+            "kms:ViaService" = "backup.${data.aws_region.current.region}.amazonaws.com"
           }
         }
       }

--- a/examples/cross_account_vault_policy/outputs.tf
+++ b/examples/cross_account_vault_policy/outputs.tf
@@ -45,7 +45,7 @@ output "cross_account_setup_summary" {
   description = "Summary of cross-account backup configuration"
   value = {
     destination_account = data.aws_caller_identity.current.account_id
-    destination_region  = data.aws_region.current.name
+    destination_region  = data.aws_region.current.region
     vault_name          = module.aws_backup_cross_account.vault_id
     vault_arn           = module.aws_backup_cross_account.vault_arn
 
@@ -104,7 +104,7 @@ output "source_account_instructions" {
             Resource = aws_kms_key.backup_vault_key.arn
             Condition = {
               StringEquals = {
-                "kms:ViaService" = "backup.${data.aws_region.current.name}.amazonaws.com"
+                "kms:ViaService" = "backup.${data.aws_region.current.region}.amazonaws.com"
               }
             }
           }
@@ -148,9 +148,9 @@ output "management_information" {
     }
 
     console_urls = {
-      backup_vault = "https://console.aws.amazon.com/backup/home?region=${data.aws_region.current.name}#/backupvaults/details/${module.aws_backup_cross_account.vault_id}"
-      backup_plan  = "https://console.aws.amazon.com/backup/home?region=${data.aws_region.current.name}#/plans"
-      kms_key      = "https://console.aws.amazon.com/kms/home?region=${data.aws_region.current.name}#/kms/keys/${aws_kms_key.backup_vault_key.key_id}"
+      backup_vault = "https://console.aws.amazon.com/backup/home?region=${data.aws_region.current.region}#/backupvaults/details/${module.aws_backup_cross_account.vault_id}"
+      backup_plan  = "https://console.aws.amazon.com/backup/home?region=${data.aws_region.current.region}#/plans"
+      kms_key      = "https://console.aws.amazon.com/kms/home?region=${data.aws_region.current.region}#/kms/keys/${aws_kms_key.backup_vault_key.key_id}"
     }
 
     monitoring = {

--- a/examples/secure_backup_configuration/kms.tf
+++ b/examples/secure_backup_configuration/kms.tf
@@ -24,7 +24,7 @@ resource "aws_kms_key" "backup_key" {
         Resource = "*"
         Condition = {
           StringEquals = {
-            "kms:ViaService" = "backup.${data.aws_region.current.id}.amazonaws.com"
+            "kms:ViaService" = "backup.${data.aws_region.current.region}.amazonaws.com"
           }
         }
       },
@@ -53,7 +53,7 @@ resource "aws_kms_key" "backup_key" {
         Resource = "*"
         Condition = {
           StringEquals = {
-            "kms:ViaService" = "backup.${data.aws_region.current.id}.amazonaws.com"
+            "kms:ViaService" = "backup.${data.aws_region.current.region}.amazonaws.com"
           }
         }
       },
@@ -61,7 +61,7 @@ resource "aws_kms_key" "backup_key" {
         Sid    = "AllowCloudWatchLogsAccess"
         Effect = "Allow"
         Principal = {
-          Service = "logs.${data.aws_region.current.id}.amazonaws.com"
+          Service = "logs.${data.aws_region.current.region}.amazonaws.com"
         }
         Action = [
           "kms:Encrypt",
@@ -73,7 +73,7 @@ resource "aws_kms_key" "backup_key" {
         Resource = "*"
         Condition = {
           ArnEquals = {
-            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/backup/*"
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/backup/*"
           }
         }
       }
@@ -158,7 +158,7 @@ resource "aws_kms_key" "cross_region_backup_key" {
         Condition = {
           StringEquals = {
             "kms:ViaService" = [
-              "backup.${data.aws_region.current.id}.amazonaws.com",
+              "backup.${data.aws_region.current.region}.amazonaws.com",
               "backup.${var.cross_region}.amazonaws.com"
             ]
           }
@@ -179,7 +179,7 @@ resource "aws_kms_key" "cross_region_backup_key" {
         Condition = {
           StringEquals = {
             "kms:ViaService" = [
-              "backup.${data.aws_region.current.id}.amazonaws.com",
+              "backup.${data.aws_region.current.region}.amazonaws.com",
               "backup.${var.cross_region}.amazonaws.com"
             ]
           }

--- a/examples/secure_backup_configuration/monitoring.tf
+++ b/examples/secure_backup_configuration/monitoring.tf
@@ -2,7 +2,7 @@
 
 # Local values for monitoring optimization
 locals {
-  current_region = data.aws_region.current.id
+  current_region = data.aws_region.current.region
 }
 
 # CloudWatch Log Group for CloudTrail backup events (optional, used if CloudTrail sends logs here)

--- a/examples/secure_backup_configuration/outputs.tf
+++ b/examples/secure_backup_configuration/outputs.tf
@@ -69,7 +69,7 @@ output "backup_dashboard_name" {
 
 output "backup_dashboard_url" {
   description = "URL to the backup monitoring dashboard"
-  value       = "https://console.aws.amazon.com/cloudwatch/home?region=${data.aws_region.current.id}#dashboards:name=${aws_cloudwatch_dashboard.backup_dashboard.dashboard_name}"
+  value       = "https://console.aws.amazon.com/cloudwatch/home?region=${data.aws_region.current.region}#dashboards:name=${aws_cloudwatch_dashboard.backup_dashboard.dashboard_name}"
 }
 
 output "sns_topic_arn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -400,11 +400,11 @@ output "region_settings_hash" {
 output "configuration_health_check" {
   description = "Configuration health check and validation status for region settings"
   value = var.enable_region_settings ? {
-    provider_region     = try(data.aws_region.current[0].id, "unknown")
+    provider_region     = try(data.aws_region.current[0].region, "unknown")
     expected_region     = var.expected_region
     strict_validation   = var.enable_strict_region_validation
-    is_region_validated = var.expected_region == null ? null : try(data.aws_region.current[0].id, "") == var.expected_region
-    validation_status   = var.expected_region == null ? "No expected region configured - validation skipped" : (try(data.aws_region.current[0].id, "") == var.expected_region ? "✓ Region validated successfully" : "⚠ WARNING: Region mismatch detected")
-    recommendation      = var.expected_region == null ? "Consider setting expected_region for multi-region deployments" : (try(data.aws_region.current[0].id, "") == var.expected_region ? "Configuration is correctly applied to the expected region" : "ATTENTION: Settings may be applied to the wrong region. Review your provider configuration or enable strict validation.")
+    is_region_validated = var.expected_region == null ? null : try(data.aws_region.current[0].region, "") == var.expected_region
+    validation_status   = var.expected_region == null ? "No expected region configured - validation skipped" : (try(data.aws_region.current[0].region, "") == var.expected_region ? "✓ Region validated successfully" : "⚠ WARNING: Region mismatch detected")
+    recommendation      = var.expected_region == null ? "Consider setting expected_region for multi-region deployments" : (try(data.aws_region.current[0].region, "") == var.expected_region ? "Configuration is correctly applied to the expected region" : "ATTENTION: Settings may be applied to the wrong region. Review your provider configuration or enable strict validation.")
   } : null
 }

--- a/region_settings.tf
+++ b/region_settings.tf
@@ -28,8 +28,8 @@ resource "aws_backup_region_settings" "this" {
   lifecycle {
     # Optional strict region validation (opt-in feature)
     precondition {
-      condition     = !var.enable_strict_region_validation || var.expected_region == null || try(data.aws_region.current[0].id, "") == var.expected_region
-      error_message = "Region mismatch detected: Provider is configured for '${try(data.aws_region.current[0].id, "unknown")}' but expected_region is set to '${var.expected_region}'. This could lead to compliance violations. To bypass this check, set enable_strict_region_validation = false."
+      condition     = !var.enable_strict_region_validation || var.expected_region == null || try(data.aws_region.current[0].region, "") == var.expected_region
+      error_message = "Region mismatch detected: Provider is configured for '${try(data.aws_region.current[0].region, "unknown")}' but expected_region is set to '${var.expected_region}'. This could lead to compliance violations. To bypass this check, set enable_strict_region_validation = false."
     }
   }
 }


### PR DESCRIPTION
The aws_region data source deprecated both `id` and `name` in favor of `region` in the AWS provider v6.x.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region#region-1