### PR TITLE
chore: align example AWS provider constraints

### DIFF
--- a/examples/cross_account_vault_policy/versions.tf
+++ b/examples/cross_account_vault_policy/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.11.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/secure_backup_configuration/versions.tf
+++ b/examples/secure_backup_configuration/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 5.0.0"
+      version               = ">= 6.11.0"
       configuration_aliases = [aws.cross_region]
     }
   }


### PR DESCRIPTION
## Summary

- Aligns the two examples touched by the `aws_region.region` migration with the root module AWS provider requirement.
- Updates example AWS provider constraints from `>= 5.0` / `>= 5.0.0` to `>= 6.11.0`.

## Why

PR #329 moved these examples to `data.aws_region.current.region`, which is available in AWS provider v6 and matches the root module constraint. The examples already resolve to v6 when used with `source = "../.."`, but the local example constraints were misleading in isolation.

## Validation

- [x] `terraform fmt -check -recursive`
- [x] `terraform -chdir=examples/cross_account_vault_policy init -backend=false -input=false`
- [x] `terraform -chdir=examples/cross_account_vault_policy validate -no-color`
- [x] `terraform -chdir=examples/secure_backup_configuration init -backend=false -input=false`
- [x] `pre-commit run --files examples/cross_account_vault_policy/versions.tf examples/secure_backup_configuration/versions.tf`

Note: `examples/secure_backup_configuration validate` still fails due to pre-existing example issues tracked in #331.
