### PR TITLE
fix: make secure backup configuration example validate

### DIFF
--- a/examples/secure_backup_configuration/main.tf
+++ b/examples/secure_backup_configuration/main.tf
@@ -34,7 +34,7 @@ locals {
         delete_after       = var.backup_retention_days
       }
       copy_actions = var.enable_cross_region_backup ? [{
-        destination_backup_vault_arn = "arn:aws:backup:${var.cross_region}:${data.aws_caller_identity.current.account_id}:backup-vault:${local.vault_name}-cross-region"
+        destination_vault_arn = "arn:aws:backup:${var.cross_region}:${data.aws_caller_identity.current.account_id}:backup-vault:${local.vault_name}-cross-region"
         lifecycle = {
           cold_storage_after = 30
           delete_after       = var.backup_retention_days
@@ -58,7 +58,7 @@ locals {
         delete_after       = var.weekly_backup_retention_days
       }
       copy_actions = var.enable_cross_region_backup ? [{
-        destination_backup_vault_arn = "arn:aws:backup:${var.cross_region}:${data.aws_caller_identity.current.account_id}:backup-vault:${local.vault_name}-cross-region"
+        destination_vault_arn = "arn:aws:backup:${var.cross_region}:${data.aws_caller_identity.current.account_id}:backup-vault:${local.vault_name}-cross-region"
         lifecycle = {
           cold_storage_after = 7
           delete_after       = var.weekly_backup_retention_days
@@ -81,51 +81,25 @@ locals {
       name = "production-databases-secure"
       # Use tag-based selection for better security instead of wildcard ARNs
       resources = ["*"]
-      conditions = [
-        {
-          string_equals = {
-            key   = "aws:tag/Environment"
-            value = var.environment
-          }
-        },
-        {
-          string_equals = {
-            key   = "aws:tag/BackupRequired"
-            value = "true"
-          }
-        },
-        {
-          string_equals = {
-            key   = "aws:tag/ResourceType"
-            value = "Database"
-          }
+      conditions = {
+        string_equals = {
+          "aws:tag/Environment"    = var.environment
+          "aws:tag/BackupRequired" = "true"
+          "aws:tag/ResourceType"   = "Database"
         }
-      ]
+      }
     }
     critical_file_systems = {
       name = "critical-file-systems-secure"
       # Use tag-based selection for better security
       resources = ["*"]
-      conditions = [
-        {
-          string_equals = {
-            key   = "aws:tag/Environment"
-            value = var.environment
-          }
-        },
-        {
-          string_equals = {
-            key   = "aws:tag/BackupTier"
-            value = "critical"
-          }
-        },
-        {
-          string_equals = {
-            key   = "aws:tag/ResourceType"
-            value = "FileSystem"
-          }
+      conditions = {
+        string_equals = {
+          "aws:tag/Environment"  = var.environment
+          "aws:tag/BackupTier"   = "critical"
+          "aws:tag/ResourceType" = "FileSystem"
         }
-      ]
+      }
     }
   }
 }
@@ -154,7 +128,7 @@ module "backup" {
   }
 
   # Secure backup selections
-  backup_selections = values(local.backup_selections)
+  backup_selections = local.backup_selections
 
   # Security and compliance tags
   tags = local.common_tags

--- a/examples/secure_backup_configuration/monitoring.tf
+++ b/examples/secure_backup_configuration/monitoring.tf
@@ -87,7 +87,7 @@ resource "aws_cloudwatch_metric_alarm" "backup_job_success" {
 }
 
 # CloudWatch Metric Filter for backup vault events (using CloudTrail patterns)
-resource "aws_logs_metric_filter" "vault_access" {
+resource "aws_cloudwatch_log_metric_filter" "vault_access" {
   name           = "${var.project_name}-${var.environment}-vault-access"
   log_group_name = aws_cloudwatch_log_group.backup_logs.name
   # Updated pattern to match actual AWS Backup CloudTrail events
@@ -177,10 +177,6 @@ resource "aws_cloudwatch_dashboard" "backup_dashboard" {
         }
       }
     ]
-  })
-
-  tags = merge(local.common_tags, {
-    Purpose = "security-monitoring"
   })
 }
 

--- a/examples/secure_backup_configuration/outputs.tf
+++ b/examples/secure_backup_configuration/outputs.tf
@@ -12,7 +12,7 @@ output "backup_vault_arn" {
 
 output "backup_vault_recovery_points" {
   description = "Number of recovery points in the backup vault"
-  value       = module.backup.vault_recovery_points
+  value       = try(module.backup.vault_recovery_points, null)
 }
 
 output "backup_kms_key_id" {
@@ -95,10 +95,10 @@ output "cross_region_replication_enabled" {
 
 output "backup_plan_names" {
   description = "Names of the backup plans created"
-  value       = module.backup.plan_names
+  value       = { for key, plan in module.backup.plans : key => plan.name }
 }
 
 output "backup_plan_ids" {
   description = "IDs of the backup plans created"
-  value       = module.backup.plan_ids
+  value       = { for key, plan in module.backup.plans : key => plan.id }
 }


### PR DESCRIPTION
## Summary
- Fix `examples/secure_backup_configuration` so it validates with the current module/provider schema
- Pass `backup_selections` as a map and normalize condition objects to the module input shape
- Use `destination_vault_arn` for copy actions, the correct CloudWatch log metric filter resource type, and remove unsupported dashboard tags
- Update example outputs to reference current module outputs safely

Closes #331

## Validation
- `terraform fmt -check -recursive`
- `terraform -chdir=examples/secure_backup_configuration init -backend=false -input=false`
- `terraform -chdir=examples/secure_backup_configuration validate -no-color`
- `pre-commit run --all-files`

All passed locally.
