### PR TITLE
ci: pin Claude Code action and model

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -195,7 +195,7 @@ jobs:
           done
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0  # Full history for reliable diff comparisons
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -606,9 +606,10 @@ jobs:
       - name: Run Claude Code Review
         id: claude
         timeout-minutes: 10
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@70a6e5256e9e2366a1ed5c041904a982ba3a328f # v1.0.135
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--model claude-sonnet-4-6"
 
           # Allow Bash permissions for pre-commit hooks and documentation updates
           allowed_tools: "Bash(pre-commit run --files),Bash(terraform fmt),Bash(terraform validate),Bash(terraform-docs)"

--- a/.github/workflows/claude-dispatch.yml
+++ b/.github/workflows/claude-dispatch.yml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 1
 
@@ -30,14 +30,15 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@eap
+        uses: anthropics/claude-code-action@70a6e5256e9e2366a1ed5c041904a982ba3a328f # v1.0.135
         with:
+          claude_args: "--model claude-sonnet-4-6"
           mode: 'remote-agent'
           # Optional: Specify an API key, otherwise we'll use your Claude account automatically
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          # model: "claude-sonnet-4-6"
 
           # Optional: Allow Claude to run specific commands
           # allowed_tools: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,22 +26,23 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@70a6e5256e9e2366a1ed5c041904a982ba3a328f # v1.0.135
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--model claude-sonnet-4-6"
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          # model: "claude-sonnet-4-6"
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"

--- a/.github/workflows/feature-discovery.yml
+++ b/.github/workflows/feature-discovery.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 1
 
@@ -169,12 +169,13 @@ jobs:
 
       - name: Run Claude Code Feature Discovery
         id: claude-discovery
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@70a6e5256e9e2366a1ed5c041904a982ba3a328f # v1.0.135
         env:
           CLAUDE_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.CLAUDE_ISSUE_TOKEN }}
         with:
           claude_code_oauth_token: ${{ env.CLAUDE_TOKEN }}
+          claude_args: "--model claude-sonnet-4-6"
           mode: agent
           github_token: ${{ secrets.CLAUDE_ISSUE_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Pin `anthropics/claude-code-action` to the latest resolved SHA (`v1.0.135`)
- Pin `actions/checkout` to the latest resolved v6 SHA in Claude workflows
- Explicitly run Claude Code with the latest Sonnet model via `claude_args: --model claude-sonnet-4-6`
- Preserve existing allowed tools, MCP config, prompts, and workflow behavior

## Validation
- Parsed changed workflow YAML files with Ruby/Psych
- Ran `git diff --check`
- Verified changed Claude workflows no longer use floating Claude Code Action refs (`v1`, `beta`, `eap`, `v1.0.0`) or stale Claude model IDs
