### PR TITLE
chore: support release-please refactor patch releases

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -3,6 +3,12 @@
     ".": {
       "release-type": "terraform-module",
       "changelog-path": "CHANGELOG.md",
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "refactor", "section": "Code Refactoring" }
+      ],
       "include-v-in-tag": false,
       "include-component-in-tag": false
     }

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ See [examples/simple_audit_framework/main.tf](examples/simple_audit_framework/ma
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
 


### PR DESCRIPTION
## Summary
- Configure release-please changelog sections so `refactor:` commits are visible as Code Refactoring release entries.
- Preserve existing `feat:`/`fix:` behavior by not switching to `always-bump-patch`; default release-please versioning still bumps features as minor and fixes/refactors as patch.
- Keep docs/CI/chore commit types out of the release changelog unless explicitly configured later.
- Include the terraform-docs generated README provider version refresh required by `pre-commit run --all-files`.

Closes #351

## Validation
- `jq empty .release-please-config.json .release-please-manifest.json .github/.release-please-config.json .github/.release-please-manifest.json` — passed
- `pnpm dlx release-please@17.9.0 --version` — passed (`17.9.0`)
- Release-please internal behavior check against v17.9.0: `refactor` visible, `docs`/`ci` hidden, refactor-only bump `1.9.0 -> 1.9.1`, feat-only bump `1.9.0 -> 1.10.0` — passed
- `pre-commit run --files .release-please-config.json` — passed
- `pre-commit run --all-files` — passed

No Terraform apply or live AWS mutation performed.
