### PR TITLE
feat: support audit framework control scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ See [examples/simple_audit_framework/main.tf](examples/simple_audit_framework/ma
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
 
@@ -182,7 +182,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_advanced_backup_settings"></a> [advanced\_backup\_settings](#input\_advanced\_backup\_settings) | Advanced backup settings by resource type | `map(map(string))` | `{}` | no |
-| <a name="input_audit_framework"></a> [audit\_framework](#input\_audit\_framework) | Configuration for AWS Backup Audit Manager framework | <pre>object({<br/>    create      = bool<br/>    name        = string<br/>    description = optional(string)<br/>    controls = list(object({<br/>      name            = string<br/>      parameter_name  = optional(string)<br/>      parameter_value = optional(string)<br/>    }))<br/>  })</pre> | <pre>{<br/>  "controls": [],<br/>  "create": false,<br/>  "description": null,<br/>  "name": null<br/>}</pre> | no |
+| <a name="input_audit_framework"></a> [audit\_framework](#input\_audit\_framework) | Configuration for AWS Backup Audit Manager framework | <pre>object({<br/>    create      = bool<br/>    name        = string<br/>    description = optional(string)<br/>    controls = list(object({<br/>      name            = string<br/>      parameter_name  = optional(string)<br/>      parameter_value = optional(string)<br/>      scope = optional(object({<br/>        compliance_resource_ids   = optional(list(string))<br/>        compliance_resource_types = optional(list(string))<br/>        tags                      = optional(map(string))<br/>      }))<br/>    }))<br/>  })</pre> | <pre>{<br/>  "controls": [],<br/>  "create": false,<br/>  "description": null,<br/>  "name": null<br/>}</pre> | no |
 | <a name="input_backup_policies"></a> [backup\_policies](#input\_backup\_policies) | Map of backup policies to create | <pre>map(object({<br/>    target_vault_name = string<br/>    schedule          = string<br/>    start_window      = number<br/>    completion_window = number<br/>    lifecycle = object({<br/>      delete_after       = number<br/>      cold_storage_after = optional(number)<br/>    })<br/>    recovery_point_tags      = optional(map(string))<br/>    copy_actions             = optional(list(map(string)))<br/>    enable_continuous_backup = optional(bool)<br/>  }))</pre> | `{}` | no |
 | <a name="input_backup_regions"></a> [backup\_regions](#input\_backup\_regions) | List of regions where backups should be created | `list(string)` | `[]` | no |
 | <a name="input_backup_selections"></a> [backup\_selections](#input\_backup\_selections) | Map of backup selections | <pre>map(object({<br/>    resources     = optional(list(string))<br/>    not_resources = optional(list(string))<br/>    conditions = optional(object({<br/>      string_equals     = optional(map(string))<br/>      string_not_equals = optional(map(string))<br/>      string_like       = optional(map(string))<br/>      string_not_like   = optional(map(string))<br/>    }))<br/>    tags = optional(map(string))<br/>  }))</pre> | `{}` | no |

--- a/audit_manager.tf
+++ b/audit_manager.tf
@@ -11,6 +11,8 @@ locals {
           value = control.parameter_value
         }
       ]
+      # Only create a scope block when one is explicitly configured
+      scope = try(control.scope, null) == null ? [] : [control.scope]
     }
   ]
 }
@@ -32,6 +34,16 @@ resource "aws_backup_framework" "ab_framework" {
         content {
           name  = input_parameter.value.name
           value = input_parameter.value.value
+        }
+      }
+
+      # Only create scope block if scope is provided
+      dynamic "scope" {
+        for_each = control.value.scope
+        content {
+          compliance_resource_ids   = scope.value.compliance_resource_ids
+          compliance_resource_types = scope.value.compliance_resource_types
+          tags                      = scope.value.tags
         }
       }
     }

--- a/examples/simple_audit_framework/README.md
+++ b/examples/simple_audit_framework/README.md
@@ -7,6 +7,7 @@ This example demonstrates how to create an AWS Backup Audit Framework with vario
 
 - Creates an AWS Backup Audit Framework
 - Configures multiple audit controls with different parameters
+- Demonstrates a control scope that targets a specific resource type
 - Demonstrates parameter handling for controls with and without parameters
 - Shows how to properly configure framework tags
 
@@ -28,7 +29,10 @@ module "aws_backup_example" {
       {
         name            = "BACKUP_RESOURCES_PROTECTED_BY_BACKUP_VAULT_LOCK"
         parameter_name  = "maxRetentionDays"
-        parameter_value = "100"  # Maximum retention period allowed by vault lock
+        parameter_value = "100" # Maximum retention period allowed by vault lock
+        scope = {
+          compliance_resource_types = ["EBS"]
+        }
       },
     ]
   }
@@ -63,6 +67,7 @@ This example includes several controls:
 5. **BACKUP_RESOURCES_PROTECTED_BY_BACKUP_VAULT_LOCK**
    - Ensures resources are protected by vault lock
    - Parameter: maxRetentionDays = 100
+   - Scope: EBS resources
 
 6. **BACKUP_LAST_RECOVERY_POINT_CREATED**
    - Monitors recent backup creation
@@ -70,9 +75,10 @@ This example includes several controls:
 
 ## Notes
 
-1. Some controls don't accept parameters and should have parameter_name and parameter_value set to null
+1. Some controls don't accept parameters and should omit parameter_name and parameter_value
 2. The framework creation can take up to 20 minutes
-3. Tags are applied at the framework level
-4. Framework policy assignments must be managed through AWS Console or AWS CLI
-5. **Important:** For the Deployment Status of the Framework to be successful, you must enable AWS Config resource tracking to monitor configuration changes of your backup resources. This can be done from the AWS Console.
+3. Control scopes can target resource types, resource IDs, or a single tag key/value pair
+4. Tags are applied at the framework level
+5. Framework policy assignments must be managed through AWS Console or AWS CLI
+6. **Important:** For the Deployment Status of the Framework to be successful, you must enable AWS Config resource tracking to monitor configuration changes of your backup resources. This can be done from the AWS Console.
 <!-- END_TF_DOCS -->

--- a/examples/simple_audit_framework/main.tf
+++ b/examples/simple_audit_framework/main.tf
@@ -14,6 +14,9 @@ module "aws_backup_example" {
         name            = "BACKUP_RESOURCES_PROTECTED_BY_BACKUP_VAULT_LOCK"
         parameter_name  = "maxRetentionDays"
         parameter_value = "100" # Maximum retention period allowed by vault lock
+        scope = {
+          compliance_resource_types = ["EBS"]
+        }
       },
     ]
   }

--- a/variables.tf
+++ b/variables.tf
@@ -535,6 +535,11 @@ variable "audit_framework" {
       name            = string
       parameter_name  = optional(string)
       parameter_value = optional(string)
+      scope = optional(object({
+        compliance_resource_ids   = optional(list(string))
+        compliance_resource_types = optional(list(string))
+        tags                      = optional(map(string))
+      }))
     }))
   })
   default = {
@@ -542,6 +547,45 @@ variable "audit_framework" {
     name        = null
     description = null
     controls    = []
+  }
+
+  validation {
+    condition = alltrue([
+      for control in var.audit_framework.controls :
+      try(control.scope.compliance_resource_ids, null) == null ? true : (
+        length(control.scope.compliance_resource_ids) >= 1 &&
+        length(control.scope.compliance_resource_ids) <= 100
+      )
+    ])
+    error_message = "audit_framework.controls[*].scope.compliance_resource_ids must contain between 1 and 100 resource IDs when specified."
+  }
+
+  validation {
+    condition = alltrue([
+      for control in var.audit_framework.controls :
+      try(control.scope.tags, null) == null ? true : length(control.scope.tags) == 1
+    ])
+    error_message = "audit_framework.controls[*].scope.tags must contain exactly one tag key/value pair when specified."
+  }
+
+  validation {
+    condition = alltrue([
+      for control in var.audit_framework.controls :
+      try(control.scope.compliance_resource_types, null) == null ? true : length(control.scope.compliance_resource_types) >= 1
+    ])
+    error_message = "audit_framework.controls[*].scope.compliance_resource_types must contain at least one resource type when specified."
+  }
+
+  validation {
+    condition = alltrue([
+      for control in var.audit_framework.controls :
+      try(control.scope, null) == null ? true : (
+        try(length(control.scope.compliance_resource_ids), 0) > 0 ||
+        try(length(control.scope.compliance_resource_types), 0) > 0 ||
+        try(length(control.scope.tags), 0) > 0
+      )
+    ])
+    error_message = "audit_framework.controls[*].scope must include at least one of compliance_resource_ids, compliance_resource_types, or tags."
   }
 }
 


### PR DESCRIPTION
## Summary

- Add optional `audit_framework.controls[*].scope` support for AWS Backup Audit Manager framework controls.
- Render provider-compatible `aws_backup_framework.control.scope` blocks only when a scope is configured.
- Add validation for scoped resource IDs and the AWS one-tag scope limit.
- Update the simple audit framework example and generated README input docs.

Closes #358

## Source checks

- Terraform Registry provider latest: `hashicorp/aws` v6.53.0.
- Provider docs checked for `aws_backup_framework` at v6.53.0 and provider floor v6.47.0; both document `control.scope` with `compliance_resource_ids`, `compliance_resource_types`, and `tags`.
- Provider schema checked at v6.47.0: `scope` exists, max 1 block; `tags` is `map(string)`.
- AWS CloudFormation `ControlScope` docs checked for resource ID length and one-tag scope limit.

## Validation

- `terraform fmt -recursive`
- `terraform init -backend=false -input=false`
- `terraform validate -no-color`
- `terraform -chdir=examples/simple_audit_framework init -backend=false -input=false`
- `terraform -chdir=examples/simple_audit_framework validate -no-color`
- `pre-commit run --all-files`

No Terraform apply or live AWS mutation was run.
