### PR TITLE
TF-Lint fixes

### DIFF
--- a/examples/cost_optimized_backup/main.tf
+++ b/examples/cost_optimized_backup/main.tf
@@ -16,8 +16,6 @@ provider "aws" {
   region = var.region
 }
 
-data "aws_caller_identity" "current" {}
-
 # Cost-optimized backup configuration with multiple tiers
 module "cost_optimized_backup" {
   source = "../.."

--- a/examples/cross_region_backup/main.tf
+++ b/examples/cross_region_backup/main.tf
@@ -23,10 +23,6 @@ provider "aws" {
   region = var.secondary_region
 }
 
-# Data sources
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
-
 # Create destination vault in secondary region
 resource "aws_backup_vault" "secondary_vault" {
   provider = aws.secondary

--- a/examples/region_settings/main.tf
+++ b/examples/region_settings/main.tf
@@ -16,8 +16,6 @@ provider "aws" {
   region = var.region
 }
 
-data "aws_caller_identity" "current" {}
-
 # Configure region settings to enable specific AWS services for backup
 module "region_settings" {
   source = "../.."

--- a/examples/secure_backup_configuration/main.tf
+++ b/examples/secure_backup_configuration/main.tf
@@ -4,31 +4,31 @@
 # Data sources for account and region information
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
-data "aws_region" "cross_region" {
-  provider = aws.cross_region
-}
 
 # Local values for consistent resource naming and configuration
 locals {
   vault_name = "${var.project_name}-${var.environment}-backup-vault"
 
-  common_tags = {
-    Environment   = var.environment
-    Project       = var.project_name
-    ManagedBy     = "terraform"
-    Purpose       = "backup"
-    SecurityLevel = "high"
-    Compliance    = "required"
-    CreatedBy     = "secure-backup-example"
-  }
+  common_tags = merge({
+    Environment         = var.environment
+    Project             = var.project_name
+    Owner               = var.owner
+    ManagedBy           = "terraform"
+    Purpose             = "backup"
+    SecurityLevel       = "high"
+    Compliance          = "required"
+    ComplianceFramework = var.compliance_framework
+    CreatedBy           = "secure-backup-example"
+  }, var.additional_tags)
 
   # Security-focused backup rules with encryption and compliance
   backup_rules = {
     critical_daily = {
-      name              = "critical-daily-encrypted"
-      schedule          = "cron(0 3 ? * * *)"
-      start_window      = 60
-      completion_window = 300
+      name                     = "critical-daily-encrypted"
+      schedule                 = "cron(0 3 ? * * *)"
+      start_window             = 60
+      completion_window        = 300
+      enable_continuous_backup = var.enable_continuous_backup
       lifecycle = {
         cold_storage_after = 30
         delete_after       = var.backup_retention_days
@@ -76,32 +76,48 @@ locals {
   }
 
   # Security-focused backup selections with specific resource targeting
-  backup_selections = {
-    production_databases = {
-      name = "production-databases-secure"
-      # Use tag-based selection for better security instead of wildcard ARNs
-      resources = ["*"]
-      conditions = {
-        string_equals = {
-          "aws:tag/Environment"    = var.environment
-          "aws:tag/BackupRequired" = "true"
-          "aws:tag/ResourceType"   = "Database"
+  backup_selections = merge(
+    {
+      production_databases = {
+        name = "production-databases-secure"
+        # Use tag-based selection for better security instead of wildcard ARNs
+        resources = ["*"]
+        conditions = {
+          string_equals = {
+            "aws:tag/Environment"    = var.environment
+            "aws:tag/BackupRequired" = "true"
+            "aws:tag/ResourceType"   = "Database"
+          }
         }
       }
-    }
-    critical_file_systems = {
-      name = "critical-file-systems-secure"
-      # Use tag-based selection for better security
-      resources = ["*"]
-      conditions = {
-        string_equals = {
-          "aws:tag/Environment"  = var.environment
-          "aws:tag/BackupTier"   = "critical"
-          "aws:tag/ResourceType" = "FileSystem"
+      critical_file_systems = {
+        name = "critical-file-systems-secure"
+        # Use tag-based selection for better security
+        resources = ["*"]
+        conditions = {
+          string_equals = {
+            "aws:tag/Environment"  = var.environment
+            "aws:tag/BackupTier"   = "critical"
+            "aws:tag/ResourceType" = "FileSystem"
+          }
         }
       }
-    }
-  }
+    },
+    # Explicit ARN-based selections, for databases/volumes that aren't (or
+    # can't be) tagged for the conditions above.
+    length(var.database_resources) > 0 ? {
+      explicit_databases = {
+        name      = "explicit-databases-secure"
+        resources = var.database_resources
+      }
+    } : {},
+    length(var.volume_resources) > 0 ? {
+      explicit_volumes = {
+        name      = "explicit-volumes-secure"
+        resources = var.volume_resources
+      }
+    } : {}
+  )
 }
 
 # Secure backup module configuration

--- a/examples/secure_backup_configuration/monitoring.tf
+++ b/examples/secure_backup_configuration/monitoring.tf
@@ -195,6 +195,15 @@ resource "aws_sns_topic" "backup_security_alerts" {
   })
 }
 
+# Email subscription for backup security alerts (conditional)
+resource "aws_sns_topic_subscription" "backup_security_alerts_email" {
+  count = var.create_sns_topic && var.notification_email != "" ? 1 : 0
+
+  topic_arn = aws_sns_topic.backup_security_alerts[0].arn
+  protocol  = "email"
+  endpoint  = var.notification_email
+}
+
 # SNS topic policy for secure access
 resource "aws_sns_topic_policy" "backup_security_alerts" {
   count = var.create_sns_topic ? 1 : 0

--- a/examples/secure_backup_configuration/outputs.tf
+++ b/examples/secure_backup_configuration/outputs.tf
@@ -77,6 +77,11 @@ output "sns_topic_arn" {
   value       = var.create_sns_topic ? aws_sns_topic.backup_security_alerts[0].arn : null
 }
 
+output "notification_email_subscribed" {
+  description = "Whether an email subscription was created for backup security alerts"
+  value       = var.create_sns_topic && var.notification_email != ""
+}
+
 # Security compliance outputs
 output "vault_lock_enabled" {
   description = "Whether vault lock is enabled for compliance"

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ locals {
     schedule_expression_timezone = var.rule_schedule_expression_timezone
     start_window                 = var.rule_start_window
     completion_window            = var.rule_completion_window
-    lifecycle = var.rule_lifecycle_cold_storage_after == null ? {} : {
+    lifecycle = var.rule_lifecycle_cold_storage_after == null ? null : {
       cold_storage_after                        = var.rule_lifecycle_cold_storage_after
       delete_after                              = var.rule_lifecycle_delete_after
       opt_in_to_archive_for_supported_resources = var.rule_lifecycle_opt_in_to_archive
@@ -72,7 +72,7 @@ locals {
   # Lifecycle validations
   lifecycle_validations = alltrue([
     for rule in local.rules : (
-      length(try(rule.lifecycle, {})) == 0 ? true : (
+      try(length(rule.lifecycle), 0) == 0 ? true : (
         # Only validate the comparison if both values are non-null
         (try(rule.lifecycle.cold_storage_after, null) == null || try(rule.lifecycle.delete_after, null) == null) ? true :
         coalesce(rule.lifecycle.cold_storage_after, 0) <= coalesce(rule.lifecycle.delete_after, var.default_lifecycle_delete_after_days)
@@ -80,7 +80,7 @@ locals {
     ) &&
     alltrue([
       for copy_action in try(rule.copy_actions, []) : (
-        length(try(copy_action.lifecycle, {})) == 0 ? true : (
+        try(length(copy_action.lifecycle), 0) == 0 ? true : (
           # Only validate the comparison if both values are non-null
           (try(copy_action.lifecycle.cold_storage_after, null) == null || try(copy_action.lifecycle.delete_after, null) == null) ? true :
           coalesce(copy_action.lifecycle.cold_storage_after, 0) <= coalesce(copy_action.lifecycle.delete_after, var.default_lifecycle_delete_after_days)
@@ -190,7 +190,7 @@ resource "aws_backup_plan" "ab_plan" {
 
       # Lifecycle
       dynamic "lifecycle" {
-        for_each = length(try(rule.value.lifecycle, {})) == 0 ? [] : [rule.value.lifecycle]
+        for_each = try(length(rule.value.lifecycle), 0) == 0 ? [] : [rule.value.lifecycle]
         content {
           cold_storage_after                        = try(lifecycle.value.cold_storage_after, var.default_lifecycle_cold_storage_after_days)
           delete_after                              = try(lifecycle.value.delete_after, var.default_lifecycle_delete_after_days)
@@ -206,7 +206,7 @@ resource "aws_backup_plan" "ab_plan" {
 
           # Copy Action Lifecycle
           dynamic "lifecycle" {
-            for_each = length(try(copy_action.value.lifecycle, {})) == 0 ? [] : [copy_action.value.lifecycle]
+            for_each = try(length(copy_action.value.lifecycle), 0) == 0 ? [] : [copy_action.value.lifecycle]
             content {
               cold_storage_after                        = try(lifecycle.value.cold_storage_after, var.default_lifecycle_cold_storage_after_days)
               delete_after                              = try(lifecycle.value.delete_after, var.default_lifecycle_delete_after_days)
@@ -319,7 +319,7 @@ resource "aws_backup_plan" "ab_plans" {
 
       # Lifecycle
       dynamic "lifecycle" {
-        for_each = length(try(rule.value.lifecycle, {})) == 0 ? [] : [rule.value.lifecycle]
+        for_each = try(length(rule.value.lifecycle), 0) == 0 ? [] : [rule.value.lifecycle]
         content {
           cold_storage_after                        = try(lifecycle.value.cold_storage_after, var.default_lifecycle_cold_storage_after_days)
           delete_after                              = try(lifecycle.value.delete_after, var.default_lifecycle_delete_after_days)
@@ -335,7 +335,7 @@ resource "aws_backup_plan" "ab_plans" {
 
           # Copy Action Lifecycle
           dynamic "lifecycle" {
-            for_each = length(try(copy_action.value.lifecycle, {})) == 0 ? [] : [copy_action.value.lifecycle]
+            for_each = try(length(copy_action.value.lifecycle), 0) == 0 ? [] : [copy_action.value.lifecycle]
             content {
               cold_storage_after                        = try(lifecycle.value.cold_storage_after, var.default_lifecycle_cold_storage_after_days)
               delete_after                              = try(lifecycle.value.delete_after, var.default_lifecycle_delete_after_days)


### PR DESCRIPTION
## Summary

Fixes a real bug surfaced by tflint: `terraform plan` fails with `Invalid function argument: argument must not be null` whenever a rule in `var.rules`/`var.plans` omits the optional `lifecycle` block — a completely normal, documented usage pattern.

## Root cause

`local.rule` (built from the legacy flat `rule_lifecycle_*` variables) set `lifecycle = {}` when disabled. But when a rule comes from `var.rules`/`var.plans` and simply omits `lifecycle`, Terraform's `optional(object({...}))` type fills it in as `lifecycle = null`, not `{}`.

Six places in `main.tf` used `length(try(rule.lifecycle, {})) == 0` to detect "no lifecycle configured." `try()` only intercepts *errors*, not `null` — so when `rule.lifecycle` evaluated cleanly to `null`, it passed straight through into `length(null)`, which Terraform rejects. Confirmed with a minimal repro: a module call with one rule that has no `lifecycle` key at all fails `terraform plan` on `main` today.

This same type inconsistency (`{}` vs. a populated object as the two branches of one ternary) is also what tripped up tflint's `aws_iam_policy_sid_invalid_characters` type-checker with "Inconsistent conditional result types" while linting `examples/simple_plan_using_variables`.

## Fix

- `main.tf`: the legacy ternary now produces `null` instead of `{}` when disabled, matching the shape `var.rules`/`var.plans` already produce.
- The 6 affected call sites switched from `length(try(x.lifecycle, {})) == 0` to `try(length(x.lifecycle), 0) == 0`, which correctly treats a `null` lifecycle as "unconfigured" (wrapping the `length()` call itself in `try`, rather than the attribute access, is what actually catches the `null` case).

## Also included (tflint cleanup)

- Removed 4 dead/unreferenced `data` sources (`cost_optimized_backup`, `cross_region_backup` ×2, `region_settings`, and a leftover `data.aws_region.cross_region` in `secure_backup_configuration`).
- `examples/secure_backup_configuration`: wired up 7 variables that were declared and documented in `terraform.tfvars.example`/README but never actually consumed — `owner`/`compliance_framework`/`additional_tags` into resource tags, `enable_continuous_backup` onto the daily rule, `database_resources`/`volume_resources` as explicit ARN-based backup selections, and `notification_email` into a new `aws_sns_topic_subscription` (the README already advertised "SNS notifications for security events", it just wasn't implemented).

## Testing

- `terraform validate` passes on the root module and every touched example.
- `terraform fmt -check -diff -recursive .` is clean.
- Reproduced the original bug and confirmed the fix with a throwaway config (mocked AWS provider) calling the module with a rule that omits `lifecycle`: `terraform plan` failed before the fix, produced a clean plan after.