### PR TITLE
fix: migrate Claude Code workflows to action v1 inputs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -139,8 +139,8 @@ jobs:
     timeout-minutes: 15  # Prevent runaway executions
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write # Claude posts the review back onto the PR
+      issues: write
       id-token: write
 
     steps:
@@ -199,8 +199,11 @@ jobs:
         with:
           fetch-depth: 0  # Full history for reliable diff comparisons
           token: ${{ secrets.GITHUB_TOKEN }}
-          # For issue_comment events, checkout the PR branch
-          ref: ${{ github.event_name == 'issue_comment' && steps.pr-checkout-info.outputs.pr_head_ref || github.ref }}
+          # For issue_comment events, checkout the PR head via refs/pull/<n>/head.
+          # The head branch name only resolves for same-repo PRs; a fork PR's
+          # branch does not exist in this repo, so checking it out by name fails
+          # with "A branch or tag with the name '<branch>' could not be found".
+          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || github.ref }}
 
       - name: Refresh git state
         id: git-refresh
@@ -208,7 +211,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_HEAD_SHA: ${{ steps.pr-checkout-info.outputs.pr_head_sha }}
-          PR_HEAD_REF: ${{ steps.pr-checkout-info.outputs.pr_head_ref }}
+          PR_NUMBER: ${{ github.event.issue.number }}
         run: |
           set -euo pipefail
 
@@ -230,14 +233,14 @@ jobs:
             EXPECTED_SHA="$PR_HEAD_SHA"
             echo "Expected SHA from PR: $EXPECTED_SHA"
 
-            # Fetch the specific PR branch to get latest changes
-            if [ -n "$PR_HEAD_REF" ]; then
-              echo "Fetching latest changes for PR branch: ${PR_HEAD_REF}"
-              git fetch origin "${PR_HEAD_REF}:${PR_HEAD_REF}" 2>/dev/null || true
+            # Fetch the PR head through the pull ref so fork PRs resolve too
+            if [ -n "$PR_NUMBER" ]; then
+              echo "Fetching latest changes for PR #${PR_NUMBER}"
+              git fetch origin "refs/pull/${PR_NUMBER}/head"
 
-              # Reset to the latest commit on the PR branch
-              echo "Resetting to latest commit on ${PR_HEAD_REF}"
-              git reset --hard "origin/${PR_HEAD_REF}"
+              # Reset to the latest commit on the PR head
+              echo "Resetting to latest commit on refs/pull/${PR_NUMBER}/head"
+              git reset --hard FETCH_HEAD
 
               NEW_SHA=$(git rev-parse HEAD)
               echo "Updated to SHA: $NEW_SHA"
@@ -609,13 +612,24 @@ jobs:
         uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1.0.159
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-sonnet-4-6"
 
-          # Allow Bash permissions for pre-commit hooks and documentation updates
-          allowed_tools: "Bash(pre-commit run --files),Bash(terraform fmt),Bash(terraform validate),Bash(terraform-docs)"
+          # v1 consolidates model and tool permissions into claude_args. The old
+          # allowed_tools/direct_prompt inputs are rejected as "Unexpected input(s)".
+          # https://github.com/anthropics/claude-code-action/blob/main/docs/migration-guide.md
+          claude_args: |
+            --model claude-sonnet-4-6
+            --allowedTools "Bash(terraform fmt:*),Bash(terraform validate:*),Bash(terraform-docs:*),Bash(pre-commit run --files:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),mcp__github_inline_comment__create_inline_comment"
 
           # Dynamic prompt based on review mode
-          direct_prompt: |
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ steps.pr-info.outputs.pr_number }}
+
+            Publish your findings on the PR itself: `gh pr comment` for the
+            summary, and `mcp__github_inline_comment__create_inline_comment`
+            (with `confirmed: true`) for specific lines. Do not return the
+            review only as a chat message.
+
             🔄 **COMMIT ANALYSIS CONTEXT**
             - **Commit SHA**: `${{ steps.verify-state.outputs.current_sha }}`
             - **Review ID**: `${{ steps.verify-state.outputs.review_id }}`

--- a/.github/workflows/claude-dispatch.yml
+++ b/.github/workflows/claude-dispatch.yml
@@ -32,20 +32,17 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1.0.159
         with:
-          claude_args: "--model claude-sonnet-4-6"
-          mode: 'remote-agent'
-          # Optional: Specify an API key, otherwise we'll use your Claude account automatically
-          # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-sonnet-4-6"
+          # v1 auto-detects the execution mode; the old `mode` input was removed
+          # and is rejected as "Unexpected input(s)".
+          # https://github.com/anthropics/claude-code-action/blob/main/docs/migration-guide.md
+          claude_args: |
+            --model claude-sonnet-4-6
 
           # Optional: Allow Claude to run specific commands
-          # allowed_tools: |
-          #   Bash(npm run lint)
-          #   Bash(npm run test)
-          #   Bash(npm run build)
+          # claude_args: |
+          #   --allowedTools "Bash(terraform fmt:*),Bash(terraform validate:*)"
 
           # Optional: Custom environment variables for Claude
-          # claude_env: |
-          #   NODE_ENV: test
+          # settings: '{"env":{"TF_IN_AUTOMATION":"1"}}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,56 +30,40 @@ jobs:
         with:
           fetch-depth: 1
 
+      # MCP servers for Terraform registry and library documentation lookups.
+      # Written to a file so the JSON stays readable in claude_args.
+      - name: Create MCP config
+        run: |
+          cat > "${RUNNER_TEMP}/mcp-config.json" << 'EOF'
+          {
+            "mcpServers": {
+              "terraform": {
+                "command": "docker",
+                "args": ["run", "-i", "--rm", "hashicorp/terraform-mcp-server:1.3.0"]
+              },
+              "context7": {
+                "command": "npx",
+                "args": ["-y", "@upstash/context7-mcp@1.0.29"]
+              }
+            }
+          }
+          EOF
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1.0.159
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-sonnet-4-6"
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-sonnet-4-6"
-
-          # Optional: Customize the trigger phrase (default: @claude)
-          # trigger_phrase: "/claude"
-
-          # Optional: Trigger when specific user is assigned to an issue
-          # assignee_trigger: "claude-bot"
-
-          # MCP Configuration for Terraform and Context7 documentation access
-          mcp_config: |
-            {
-              "mcpServers": {
-                "terraform": {
-                  "command": "npx",
-                  "args": [
-                    "-y",
-                    "@modelcontextprotocol/server-terraform@latest"
-                  ]
-                },
-                "context7": {
-                  "command": "npx",
-                  "args": [
-                    "-y",
-                    "@upstash/context7-mcp@latest"
-                  ]
-                }
-              }
-            }
-
-          # Allow Bash permissions for pre-commit hooks and documentation updates + MCP tools
-          allowed_tools: "Bash(pre-commit run --files),Bash(terraform fmt),Bash(terraform validate),Bash(terraform-docs),mcp__terraform-server__getProviderDocs,mcp__terraform-server__resolveProviderDocID,mcp__terraform-server__searchModules,mcp__terraform-server__moduleDetails,mcp__context7__resolve-library-id,mcp__context7__get-library-docs"
-
-          # Optional: Add custom instructions for Claude to customize its behavior for your project
-          # custom_instructions: |
-          #   Follow our coding standards
-          #   Ensure all new code has tests
-          #   Use TypeScript for new files
-
-          # Optional: Custom environment variables for Claude
-          # claude_env: |
-          #   NODE_ENV: test
+          # v1 consolidates model, tool permissions and MCP config into claude_args.
+          # The old mcp_config/allowed_tools/model inputs are rejected as
+          # "Unexpected input(s)" and silently ignored.
+          # https://github.com/anthropics/claude-code-action/blob/main/docs/migration-guide.md
+          claude_args: |
+            --model claude-sonnet-4-6
+            --mcp-config ${{ runner.temp }}/mcp-config.json
+            --allowedTools "Bash(terraform fmt:*),Bash(terraform validate:*),Bash(terraform-docs:*),Bash(pre-commit run --files:*),mcp__terraform__search_providers,mcp__terraform__get_provider_details,mcp__terraform__get_latest_provider_version,mcp__terraform__search_modules,mcp__terraform__get_module_details,mcp__context7__resolve-library-id,mcp__context7__get-library-docs"


### PR DESCRIPTION
## Problem

`@claude` and `codebot` stopped working on PRs (see #365, where both produced nothing).

Three independent breakages, all visible in the run logs:

**1. Deprecated action inputs are silently ignored.** Every Claude workflow still passes v0.x inputs to `claude-code-action` v1.0.159. GitHub logs them as a warning and drops them:

```
##[warning]Unexpected input(s) 'mcp_config', 'allowed_tools', valid inputs are
['trigger_phrase', ..., 'prompt', ..., 'claude_args', ...]
```

So the review workflow ran with **no prompt at all** (`direct_prompt` dropped), and both ran with no MCP servers and no tool permissions.

**2. `claude-code-review` cannot check out fork PRs.** It resolved the PR head branch by name against this repo, which only exists for same-repo PRs. On #365 (from `mitter91/terraform-aws-backup`) the run failed with:

```
##[error]A branch or tag with the name 'tflint-fix-add-sns-subscription' could not be found
```

**3. The review job had no write access.** `pull-requests: read` / `issues: read` meant Claude could not post its findings even if it produced them. In v1, automation mode (`prompt`) does not create a comment on its own — Claude has to publish the review itself.

Separately, `claude.yml` pointed its terraform MCP server at `@modelcontextprotocol/server-terraform`, which does not exist on npm (`404`), and allow-listed `mcp__terraform-server__*` tools that would not have matched the `terraform` server key anyway.

## Changes

- Move `model`, `allowed_tools` and `mcp_config` into `claude_args` CLI flags; rename `direct_prompt` → `prompt`. ([migration guide](https://github.com/anthropics/claude-code-action/blob/main/docs/migration-guide.md))
- Drop `mode: 'remote-agent'` from `claude-dispatch.yml` (auto-detected in v1) and give it the same `CLAUDE_CODE_OAUTH_TOKEN` the other workflows use.
- Swap the nonexistent npm terraform MCP package for the official `hashicorp/terraform-mcp-server:1.3.0` image, written to `$RUNNER_TEMP/mcp-config.json`, with tool names matching the server key.
- Check out and refresh fork PRs through `refs/pull/<n>/head` instead of the branch name.
- Grant `pull-requests: write` / `issues: write` to the review job and instruct Claude to publish via `gh pr comment` and inline comments.

## Verification

- All workflow YAML parses.
- `pre-commit run --files` clean on the three changed files.
- End-to-end behavior can only be confirmed once this is on `master`, since these workflows run from the base branch.

## Follow-up (not in this PR)

`CLAUDE_CODE_OAUTH_TOKEN` was last set **2025-07-18**. The run on #365 errored after 1.8s with zero model turns, never getting past the action's own placeholder comment — the signature of an auth failure. The token likely needs regenerating with `claude setup-token`.